### PR TITLE
fix: correctness fixes and verified cleanups from full-codebase audit

### DIFF
--- a/cmd/image/commands.go
+++ b/cmd/image/commands.go
@@ -16,8 +16,7 @@ type Actions interface {
 
 // Command builds the `image` subcommand tree against the given handler.
 func Command(h Actions) *cobra.Command {
-	imageCmd := &cobra.Command{Use: "image", Short: "Manage macOS disk images (reuses cocoon's cloudimg store)"}
-	imageCmd.PersistentFlags().String("state-dir", "", "image/VM state root (default $COCOON_MACOS_HOME or /var/lib/cocoon-macos)")
+	imageCmd := &cobra.Command{Use: "image", Short: "Manage macOS disk images (reuses cocoon's cloudimg store)"} // --state-dir is a root persistent flag
 
 	pull := &cobra.Command{
 		Use:   "pull REF",

--- a/cmd/image/handler.go
+++ b/cmd/image/handler.go
@@ -40,6 +40,13 @@ func (h *Handler) Pull(cmd *cobra.Command, args []string) error {
 	if isURL(ref) {
 		return s.Pull(ctx, ref, force, progress.Nop)
 	}
+	// mirror the URL path's idempotency: skip the multi-GiB oras download when already present
+	if !force {
+		if img, ierr := s.Inspect(ctx, ref); ierr == nil && img != nil {
+			log.WithFunc("cmd.image.Pull").Infof(ctx, "image %s already present (use --force to re-pull)", ref)
+			return nil
+		}
+	}
 	// Shell out to the `oras` CLI rather than oras-go: the CLI is the authoritative ghcr transport,
 	// reusing the user's docker credentials and the registry token dance transparently, and oras-go is
 	// not in the dependency tree. Migrating to the oras-go SDK is tracked as tech debt.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cocoonstack/cocoon-macos/cmd/image"
 	"github.com/cocoonstack/cocoon-macos/cmd/vm"
+	"github.com/cocoonstack/cocoon-macos/home"
 	"github.com/cocoonstack/cocoon-macos/version"
 )
 
@@ -44,6 +45,8 @@ func run(ctx context.Context) error {
 		SilenceErrors: true, // we log the error ourselves in Execute; don't let cobra double-print it
 	}
 	root.SetVersionTemplate("{{.Version}}")
+	// app-global like cocoon's root-dir: registered once here, inherited by every subcommand
+	root.PersistentFlags().String("state-dir", "", "state root (default $COCOON_MACOS_HOME or "+home.Default+")")
 	root.AddCommand(vm.Command(vm.NewHandler()))
 	root.AddCommand(image.Command(image.NewHandler()))
 	return root.ExecuteContext(ctx)

--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -27,23 +26,11 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if name == "" {
 		name = src + "-clone-" + time.Now().Format("150405")
 	}
-	dir := home.VMDir(cmd, name)
-	if err = os.MkdirAll(dir, 0o750); err != nil {
-		return fmt.Errorf("mkdir vm dir: %w", err)
-	}
-	ctx := home.Ctx(cmd)
-	base, digest, err := resolveBase(cmd, srcRec.Image, name)
+	dir, overlay, ovmfVars, digest, err := scaffoldVM(cmd, name, srcRec.Image, srcRec.OVMFVars, filepath.Base(srcRec.OVMFVars))
 	if err != nil {
 		return err
 	}
-	overlay := filepath.Join(dir, "disk.qcow2")
-	if err = bakeOverlay(ctx, base, overlay); err != nil {
-		return err
-	}
-	ovmfVars := filepath.Join(dir, filepath.Base(srcRec.OVMFVars))
-	if err = utils.ReflinkCopy(ovmfVars, srcRec.OVMFVars); err != nil {
-		return fmt.Errorf("copy OVMF_VARS: %w", err)
-	}
+	ctx := home.Ctx(cmd)
 	r := &record{
 		Name: name, Image: srcRec.Image, ImageDigest: digest, Disk: overlay,
 		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: srcRec.CPUs, Memory: srcRec.Memory,
@@ -79,7 +66,7 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	r.NetMode, _ = cmd.Flags().GetString("net")
 	tapFlag, _ := cmd.Flags().GetString("tap")
 	r.Tap = tapFlag
-	if err = applyNet(cmd, r, tapFlag); err != nil {
+	if err = applyNet(cmd, r); err != nil {
 		return err
 	}
 	if err := saveRec(dir, r); err != nil {

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -25,9 +25,7 @@ type Actions interface {
 
 // Command builds the `vm` subcommand tree against the given handler.
 func Command(h Actions) *cobra.Command {
-	vmCmd := &cobra.Command{Use: "vm", Short: "Manage macOS VMs"}
-	// state-dir applies to every subcommand (locating VM records), so make it persistent
-	vmCmd.PersistentFlags().String("state-dir", "", "VM state root (default $COCOON_MACOS_HOME or /var/lib/cocoon-macos)")
+	vmCmd := &cobra.Command{Use: "vm", Short: "Manage macOS VMs"} // --state-dir is a root persistent flag
 
 	createCmd := &cobra.Command{
 		Use:   "create [flags] IMAGE",

--- a/cmd/vm/helper.go
+++ b/cmd/vm/helper.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -57,9 +58,51 @@ func bakeOverlay(ctx context.Context, base, dst string) error {
 	return nil
 }
 
-// applyNet provisions networking for r and records the result. userTap is the user's --tap value:
-// an auto-created TAP is "owned" (torn down on rm) only when the user did not pass --tap.
-func applyNet(cmd *cobra.Command, r *record, userTap string) error {
+// scaffoldVM lays down a new VM's directory: refuses an existing record (a second create/clone
+// under the same name would truncate the live overlay and orphan its qemu), then bakes the disk
+// overlay on the resolved base and copies the OVMF_VARS template.
+func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir, overlay, ovmfVars, digest string, err error) {
+	dir = home.VMDir(cmd, name)
+	if _, statErr := os.Stat(filepath.Join(dir, "vm.json")); statErr == nil {
+		return "", "", "", "", fmt.Errorf("vm %q already exists; rm it first or pick another --name", name)
+	}
+	if err = utils.EnsureDirs(dir); err != nil {
+		return "", "", "", "", err
+	}
+	base, digest, err := resolveBase(cmd, image, name)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	overlay = filepath.Join(dir, "disk.qcow2")
+	if err = bakeOverlay(home.Ctx(cmd), base, overlay); err != nil {
+		return "", "", "", "", err
+	}
+	ovmfVars = filepath.Join(dir, varsName)
+	if err = utils.ReflinkCopy(ovmfVars, varsSrc); err != nil {
+		return "", "", "", "", fmt.Errorf("copy OVMF_VARS: %w", err)
+	}
+	return dir, overlay, ovmfVars, digest, nil
+}
+
+// prepareNet provisions host-side networking and returns the TAP ifname, the netns path (CNI;
+// "" otherwise) and the guest MAC. user-mode and a pre-created --tap need no provisioning; every
+// other mode goes through the per-OS provisionNet.
+func prepareNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err error) {
+	switch r.NetMode {
+	case "", netUser:
+		return "", "", r.MAC, nil
+	case netTAP:
+		if r.Tap != "" { // user pre-created the TAP (already on a bridge / cocoon CNI) — use verbatim
+			return r.Tap, "", r.MAC, nil
+		}
+	}
+	return provisionNet(cmd, r)
+}
+
+// applyNet provisions networking for r and records the result. r.Tap at entry is the user's
+// --tap value: an auto-created TAP is "owned" (torn down on rm) only when the user did not pass one.
+func applyNet(cmd *cobra.Command, r *record) error {
+	userTap := r.Tap
 	netTap, netns, mac, err := prepareNet(cmd, r)
 	if err != nil {
 		return err
@@ -158,17 +201,15 @@ func resolveFirmware(cmd *cobra.Command) (opencore, code, vars string, err error
 
 // setVNCPassword applies the VNC password over the HMP monitor (QEMU was started with
 // password=on); macOS Screen Sharing needs password auth, not QEMU's default "None".
-func setVNCPassword(monSock, pw string) error {
+func setVNCPassword(ctx context.Context, monSock, pw string) error {
 	var conn net.Conn
-	var err error
-	for range 50 {
-		if conn, err = net.Dial("unix", monSock); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if err != nil {
-		return fmt.Errorf("dial monitor: %w", err)
+	var dialErr error
+	// the monitor socket appears asynchronously after -daemonize
+	if err := utils.WaitFor(ctx, 5*time.Second, 100*time.Millisecond, func() (bool, error) {
+		conn, dialErr = net.Dial("unix", monSock)
+		return dialErr == nil, nil
+	}); err != nil {
+		return fmt.Errorf("dial monitor: %w", cmp.Or(dialErr, err))
 	}
 	defer func() { _ = conn.Close() }()
 	// Wait for the HMP prompt before sending: right after -daemonize the monitor accepts the

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -93,12 +93,23 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 	ctx := home.Ctx(cmd)
 	for _, n := range args {
 		dir := home.VMDir(cmd, n)
-		if r, err := loadRec(dir); err == nil {
-			terminate(ctx, r, grace)
-			teardownNet(cmd, r)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			fmt.Println(n) // nothing to remove (and no dir to hold the flock in)
+			continue
 		}
-		if err := os.RemoveAll(dir); err != nil {
-			return fmt.Errorf("remove vm dir: %w", err)
+		// same per-VM flock as stop/start/snapshot, so a concurrent start can't relaunch qemu
+		// between terminate and RemoveAll; the held lock fd stays valid across the unlink
+		if err := withVMLock(ctx, dir, func() error {
+			if r, err := loadRec(dir); err == nil {
+				terminate(ctx, r, grace)
+				teardownNet(cmd, r)
+			}
+			if err := os.RemoveAll(dir); err != nil {
+				return fmt.Errorf("remove vm dir: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 		fmt.Println(n)
 	}
@@ -115,23 +126,11 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if err != nil {
 		return nil, err
 	}
-	dir := home.VMDir(cmd, name)
-	if err = os.MkdirAll(dir, 0o750); err != nil {
-		return nil, fmt.Errorf("mkdir vm dir: %w", err)
-	}
-	ctx := home.Ctx(cmd)
-	base, digest, err := resolveBase(cmd, image, name)
+	dir, overlay, ovmfVars, digest, err := scaffoldVM(cmd, name, image, varsTmpl, "OVMF_VARS.fd")
 	if err != nil {
 		return nil, err
 	}
-	overlay := filepath.Join(dir, "disk.qcow2")
-	if err = bakeOverlay(ctx, base, overlay); err != nil {
-		return nil, err
-	}
-	ovmfVars := filepath.Join(dir, "OVMF_VARS.fd")
-	if err = utils.ReflinkCopy(ovmfVars, varsTmpl); err != nil {
-		return nil, fmt.Errorf("copy OVMF_VARS: %w", err)
-	}
+	ctx := home.Ctx(cmd)
 	cpus, _ := cmd.Flags().GetInt("cpus")
 	mem, _ := cmd.Flags().GetString("memory")
 	vnc, _ := cmd.Flags().GetInt("vnc")
@@ -150,7 +149,7 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if err = prepareOpenCore(ctx, dir, oc, randomSMBIOS, r); err != nil {
 		return nil, err
 	}
-	if err = applyNet(cmd, r, tap); err != nil {
+	if err = applyNet(cmd, r); err != nil {
 		return nil, err
 	}
 	return r, saveRec(dir, r)
@@ -191,7 +190,7 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 		r.PID = pid
 	}
 	if r.VNCPass != "" {
-		if err := setVNCPassword(spec.MonSock, r.VNCPass); err != nil {
+		if err := setVNCPassword(ctx, spec.MonSock, r.VNCPass); err != nil {
 			logger.Warnf(ctx, "set vnc password: %v", err)
 		}
 	}

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -53,18 +53,8 @@ func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
 	return nil, fmt.Errorf("unknown --net mode %q (want user|tap|cni|bridge)", r.NetMode)
 }
 
-// prepareNet provisions host-side networking and returns the TAP ifname, the netns path (CNI;
-// "" otherwise) and the guest MAC. user-mode and a pre-created --tap need no provisioning; every
-// other mode auto-creates a TAP via cocoon (the SAME forwarding plane as cocoon's CH/FC VMs).
-func prepareNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err error) {
-	switch r.NetMode {
-	case "", netUser:
-		return "", "", r.MAC, nil
-	case netTAP:
-		if r.Tap != "" { // user pre-created the TAP (already on a bridge / cocoon CNI) — use verbatim
-			return r.Tap, "", r.MAC, nil
-		}
-	}
+// provisionNet auto-creates a TAP via cocoon — the SAME forwarding plane as cocoon's CH/FC VMs.
+func provisionNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err error) {
 	provider, err := newProvider(cmd, r)
 	if err != nil {
 		return "", "", "", err
@@ -93,8 +83,12 @@ func teardownNet(cmd *cobra.Command, r *record) {
 	if !r.TapOwned {
 		return
 	}
-	if provider, err := newProvider(cmd, r); err == nil {
-		_, _ = provider.Delete(home.Ctx(cmd), []string{r.VMID})
+	ctx := home.Ctx(cmd)
+	// warn instead of failing: rm must proceed, but a leaked TAP/netns should leave a trail
+	if provider, err := newProvider(cmd, r); err != nil {
+		log.WithFunc("cmd.vm.teardownNet").Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
+	} else if _, err := provider.Delete(ctx, []string{r.VMID}); err != nil {
+		log.WithFunc("cmd.vm.teardownNet").Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
 	}
 	// CleanupTAPs runs unconditionally: it removes bt<vmid>-* by name and must not be gated on
 	// newProvider succeeding (rm has no --bridge flag), or an auto-created TAP would leak.

--- a/cmd/vm/net_other.go
+++ b/cmd/vm/net_other.go
@@ -11,22 +11,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// prepareNet on non-Linux supports only user-mode and a pre-created --tap; auto-create / CNI /
-// bridge need CAP_NET_ADMIN + netlink + netns, so they are Linux-only.
-func prepareNet(_ *cobra.Command, r *record) (tap, netns, mac string, err error) {
-	switch r.NetMode {
-	case "", netUser:
-		return "", "", r.MAC, nil
-	case netTAP:
-		if r.Tap != "" {
-			return r.Tap, "", r.MAC, nil
-		}
-	}
+// provisionNet on non-Linux always fails: auto-create / CNI / bridge need CAP_NET_ADMIN +
+// netlink + netns, so they are Linux-only.
+func provisionNet(_ *cobra.Command, _ *record) (tap, netns, mac string, err error) {
 	return "", "", "", fmt.Errorf("auto-create TAP / CNI / bridge networking requires Linux (running on %s); pass a pre-created --tap or use --net user", runtime.GOOS)
 }
 
 func teardownNet(_ *cobra.Command, _ *record) {}
 
+// launchCmd builds the qemu exec; qemu-system-x86_64 is the authoritative VMM with no Go-native
+// equivalent (and off Linux there is no netns to enter).
 func launchCmd(_ *record, args []string) *exec.Cmd {
 	return exec.Command(qemuBinary, args...)
 }

--- a/cmd/vm/query.go
+++ b/cmd/vm/query.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,7 +28,7 @@ func (h *Handler) List(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintln(w, "NAME\tSTATE\tCPU\tMEM\tNET\tVNC\tSSH\tIMAGE\tCREATED") //nolint:errcheck
 		for _, r := range recs {
 			fmt.Fprintf(w, "%s\t%s\t%d\t%sM\t%s\t%s\t%s\t%s\t%s\n", //nolint:errcheck
-				r.Name, vmState(r), r.CPUs, r.Memory, netCol(r),
+				r.Name, vmState(r), r.CPUs, r.Memory, cmp.Or(r.NetMode, netUser),
 				vncCol(r), sshCol(r), r.Image, cli.FormatTime(r.Created))
 		}
 	})
@@ -42,13 +43,22 @@ func (h *Handler) Inspect(cmd *cobra.Command, args []string) error {
 	return cli.OutputJSON(r)
 }
 
-// Console prints the VNC display and SSH command for reaching a VM.
+// Console prints the VNC endpoint and SSH command for reaching a VM ("-" when disabled),
+// deriving both from the same helpers vm list uses so the 5900+display rule lives in one place.
 func (h *Handler) Console(cmd *cobra.Command, args []string) error {
 	r, err := loadRec(home.VMDir(cmd, args[0]))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("VNC 127.0.0.1:590%d   SSH: ssh -p %d cocoon@localhost\n", r.VNCDisp, r.SSHPort)
+	vnc := vncCol(r)
+	if vnc != "-" {
+		vnc = "127.0.0.1:" + vnc
+	}
+	ssh := "-"
+	if r.SSHPort > 0 {
+		ssh = fmt.Sprintf("ssh -p %d cocoon@localhost", r.SSHPort)
+	}
+	fmt.Printf("VNC %s   SSH: %s\n", vnc, ssh)
 	return nil
 }
 
@@ -57,13 +67,6 @@ func vmState(r *record) string {
 		return "running"
 	}
 	return "stopped"
-}
-
-func netCol(r *record) string {
-	if r.NetMode == "" {
-		return "user"
-	}
-	return r.NetMode
 }
 
 func vncCol(r *record) string {

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -89,7 +88,7 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 // the firmware vars do NOT roll back — only guest disk state does).
 func imagesToSnapshot(r *record) []string {
 	imgs := []string{r.Disk}
-	if strings.HasSuffix(r.OVMFVars, ".qcow2") {
+	if qemu.IsQcow2NVRAM(r.OVMFVars) {
 		imgs = append(imgs, r.OVMFVars)
 	}
 	return imgs

--- a/qemu/inject.go
+++ b/qemu/inject.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/projecteru2/core/log"
 	"howett.net/plist"
 
 	"github.com/cocoonstack/cocoon/utils"
@@ -21,14 +22,15 @@ import (
 // module. The shipped OpenCore runs Automatic=true + Vault=Optional, so Generic is the SMBIOS source
 // and no vault signature rejects the edit.
 func InjectConfig(ctx context.Context, ocPath string, sm *SMBIOS) error {
-	_ = exec.Command("modprobe", "nbd", "max_part=8").Run()
-	nbd, err := freeNBD()
+	_ = exec.CommandContext(ctx, "modprobe", "nbd", "max_part=8").Run()
+	nbd, err := findFreeNBD()
 	if err != nil {
 		return err
 	}
-	if out, cerr := exec.Command("qemu-nbd", "--connect="+nbd, "-f", "qcow2", ocPath).CombinedOutput(); cerr != nil {
+	if out, cerr := exec.CommandContext(ctx, "qemu-nbd", "--connect="+nbd, "-f", "qcow2", ocPath).CombinedOutput(); cerr != nil {
 		return fmt.Errorf("connect qemu-nbd %s (output: %s): %w", nbd, out, cerr)
 	}
+	// cleanup stays on plain exec.Command: it must still run after ctx cancellation
 	defer disconnectNBD(ctx, nbd, ocPath)
 	waitForPart(ctx, nbd)
 	mnt, err := os.MkdirTemp("", "oc-efi-")
@@ -38,7 +40,7 @@ func InjectConfig(ctx context.Context, ocPath string, sm *SMBIOS) error {
 	defer func() { _ = os.RemoveAll(mnt) }()
 	var mountErr error
 	for _, p := range []string{nbd + "p1", nbd + "p2", nbd} {
-		if mountErr = exec.Command("mount", p, mnt).Run(); mountErr == nil {
+		if mountErr = exec.CommandContext(ctx, "mount", p, mnt).Run(); mountErr == nil {
 			break
 		}
 	}
@@ -56,37 +58,34 @@ func waitForPart(ctx context.Context, nbd string) {
 		if _, err := os.Stat(nbd + "p1"); err == nil {
 			return true, nil
 		}
-		_ = exec.Command("partprobe", nbd).Run()
+		_ = exec.CommandContext(ctx, "partprobe", nbd).Run()
 		return false, nil
 	})
 }
 
-// disconnectNBD tears down the qemu-nbd mapping and waits until the qcow2 is no longer held
-// open by any process. qemu-nbd --disconnect releases the device asynchronously and the server
-// pid is not /sys/block/nbdX/pid, so returning early would let the qemu launch race in and fail
-// with "Failed to get shared write lock".
+// disconnectNBD tears down the qemu-nbd mapping and waits until the qcow2 is no longer held.
+// qemu-nbd --disconnect releases the device asynchronously and the server pid is not
+// /sys/block/nbdX/pid, so returning early would let the qemu launch race in and fail with
+// "Failed to get shared write lock".
 func disconnectNBD(ctx context.Context, nbd, ocPath string) {
 	_ = exec.Command("qemu-nbd", "--disconnect", nbd).Run()
-	_ = utils.WaitFor(ctx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
-		return !fileHeld(ocPath), nil
-	})
+	if err := utils.WaitFor(ctx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
+		return !isFileHeld(ocPath), nil
+	}); err != nil {
+		// surfaces the failure the godoc warns about instead of leaving no diagnostic trail
+		log.WithFunc("qemu.disconnectNBD").Warnf(ctx, "qcow2 %s still held after nbd disconnect: %v", ocPath, err)
+	}
 }
 
-func fileHeld(path string) bool {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		abs = path
-	}
-	fds, _ := filepath.Glob("/proc/[0-9]*/fd/*")
-	for _, fd := range fds {
-		if tgt, err := os.Readlink(fd); err == nil && tgt == abs {
-			return true
-		}
-	}
-	return false
+// isFileHeld reports whether a qemu-nbd server still has ocPath open, by matching its cmdline
+// (one /proc walk) — cheaper than scanning every process's fd table, and the daemonized server
+// is the only holder to wait out.
+func isFileHeld(ocPath string) bool {
+	pids, err := utils.FindVMMByCmdline("qemu-nbd", ocPath)
+	return err == nil && len(pids) > 0
 }
 
-func freeNBD() (string, error) {
+func findFreeNBD() (string, error) {
 	for i := range 16 {
 		if _, err := os.Stat(fmt.Sprintf("/dev/nbd%d", i)); err != nil {
 			continue

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -41,12 +41,18 @@ type Spec struct {
 	QMPSock string
 }
 
+// IsQcow2NVRAM reports whether the NVRAM file is qcow2 (by suffix). Single source of the rule
+// that decides both the pflash -drive format below and whether NVRAM participates in
+// qcow2-internal snapshots (a raw .fd can't hold them) — the two must stay in lockstep.
+func IsQcow2NVRAM(path string) bool {
+	return strings.HasSuffix(path, ".qcow2")
+}
+
 // Args returns the qemu-system-x86_64 argument vector for the macOS guest.
 func (s Spec) Args() []string {
 	cores := max(s.CPUs/2, 1)
-	// NVRAM rolls back under qemu-img snapshot only if it's qcow2; a raw .fd is loaded as raw.
 	varsFmt := "raw"
-	if strings.HasSuffix(s.OVMFVars, ".qcow2") {
+	if IsQcow2NVRAM(s.OVMFVars) {
 		varsFmt = "qcow2"
 	}
 	// 2 MiB hugetlb pages cut TLB/EPT pressure on a memory-heavy GUI guest, but the host must have


### PR DESCRIPTION
## Summary

### Bug fixes (user-visible)
- **`vm console` printed wrong endpoints.** The VNC line used `590%d` (so display 10 rendered as `59010`, not `5910`) and the disabled defaults produced `590-1` / `ssh -p 0`. It now derives the VNC endpoint and SSH command from the same `vncCol`/`sshCol` helpers `vm list` uses, printing `-` when either is disabled.
- **`vm create`/`run`/`clone` with an existing `--name` silently clobbered a live VM.** A second call under the same name truncated the running VM's disk overlay and orphaned its qemu. `scaffoldVM` now refuses when a record already exists (`vm "<name>" already exists; rm it first or pick another --name`).
- **`vm rm` raced concurrent lifecycle ops.** It was the one handler not taking the per-VM flock, so a concurrent `start` could relaunch qemu between `terminate` and `RemoveAll`. `rm` now runs terminate/teardown/`RemoveAll` under `withVMLock` (tolerating a missing dir).
- **`image pull` ignored `--force` for OCI/ghcr refs.** It re-downloaded multi-GiB artifacts already in the store. It now mirrors the URL path's idempotency check and skips the `oras` download when the ref is present (unless `--force`).

### Hardening
- `teardownNet` and `disconnectNBD` now **warn on best-effort failures** instead of swallowing them, so a leaked TAP/netns or a still-held qcow2 leaves a diagnostic trail.
- `setVNCPassword` and the `InjectConfig` forward path take **`ctx`** (dial-retry via `utils.WaitFor`; subprocesses via `CommandContext`). NBD cleanup deliberately stays on plain `exec.Command` so it still runs after cancellation.

### Refactors (no behavior change)
- `isFileHeld` uses `utils.FindVMMByCmdline` (one `/proc` walk) instead of scanning every process's fd table 10x/s during NBD disconnect.
- `--state-dir` registered once on the root command (was duplicated per-subtree with drifted help text); `qemu.IsQcow2NVRAM` is the single source of the NVRAM-format rule (was duplicated across launch args and snapshot selection).
- Extracted `scaffoldVM` (shared create/clone block); hoisted the OS-independent `prepareNet` head over the per-OS `provisionNet`; dropped `applyNet`'s derivable param; `utils.EnsureDirs`; `findFreeNBD`/`isFileHeld` renames; `cmp.Or` for the net column.

## Validation
- `gofumpt -l .` — clean
- `go build ./...` and `GOOS=linux go build ./...` — ok
- `GOOS=darwin golangci-lint run ./...` and `GOOS=linux golangci-lint run ./...` — 0 issues each
- `go test -race -count=1 ./...` — pass
- Smoke-tested against a temp `--state-dir`: `vm console` now prints `VNC 127.0.0.1:5910   SSH: ssh -p 2222 cocoon@localhost` (and `-`/`-` when disabled); the duplicate-name guard refuses `create --name <existing>` and leaves the record dir untouched (no truncated overlay); `vm rm` prints and exits 0 for a missing name and terminates + removes the dir under the flock for an existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
