### PR TITLE
ci: build images with the production LongQT OpenCore + unified CPU recipe

### DIFF
--- a/.github/workflows/build-macos-image.yml
+++ b/.github/workflows/build-macos-image.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            qemu-system-x86 qemu-utils dmg2img socat netpbm python3-pip tesseract-ocr python3-pil sshpass
+            qemu-system-x86 qemu-utils ovmf gdisk dosfstools parted \
+            dmg2img socat netpbm python3-pip tesseract-ocr python3-pil sshpass
 
       - name: Verify KVM (load-bearing — gates the whole build)
         run: |

--- a/README.md
+++ b/README.md
@@ -131,9 +131,14 @@ where it lands on ghcr (the build script derives `MACOS_SHORTNAME`/`GHCR_REPO`/`
 | `slim` | pull `<repo>:<tag>` → boot → reclaim stale clusters → re-push `<repo>:<tag>` (smaller) |
 | `verify` | pull `<repo>:<tag>` → boot → confirm login + SSH (`cocoon@localhost`) |
 
-Same OSX-KVM (multi-version OpenCore) + the same provision recipe build either OS — only the
-recovery shortname + tag differ. This pipeline is **image-only** (no Go); the CLI end-to-end
-(`vm run` + `--random-smbios`) is exercised on a KVM testbed, keeping image and Go CI separate.
+CI now boots the **exact same firmware stack production uses**: the LongQT OpenCore baked by
+`scripts/lib-firmware.sh` (the same bake `doctor.sh` runs), apt `ovmf` 4M firmware
+(`OVMF_CODE_4M.fd` + `OVMF_VARS_4M.fd`), and the unified `Skylake-Client-v4,vendor=GenuineIntel,kvm=on`
+CPU. One stack everywhere means an image validated in CI boots identically on the Intel/AMD hosts the
+CLI runs on. kholia/OSX-KVM is cloned **only** for `fetch-macOS-v2.py` (the Apple recovery download).
+The same provision recipe builds either OS — only the recovery shortname + tag differ. This pipeline
+is **image-only** (no Go); the CLI end-to-end (`vm run` + `--random-smbios`) is exercised on a KVM
+testbed, keeping image and Go CI separate.
 
 Automation primitives (`scripts/qmp-input.py`): QMP absolute mouse click/move, keyboard
 type/chord, **tesseract+PIL OCR-click and title routing** (drives the macOS GUI installer where

--- a/scripts/build-qemu-macos.sh
+++ b/scripts/build-qemu-macos.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Build a golden macOS qcow2 on an x86 Linux/KVM host and push it to ghcr. Which macOS is set by
 # MACOS_SHORTNAME (+ GHCR_REPO/GHCR_TAG/QCOW2_NAME) — the workflow derives them from its `macos`
-# input: tahoe=26 (the last Intel macOS) or sequoia=15. Leans on kholia/OSX-KVM (multi-version
-# OpenCore): it provides fetch-macOS-v2.py, OVMF, OpenCore.qcow2 and the OSK.
+# input: tahoe=26 (the last Intel macOS) or sequoia=15. Boots the exact firmware stack production
+# uses: the LongQT OpenCore baked by scripts/lib-firmware.sh + apt ovmf (OVMF_*_4M.fd) + a
+# GenuineIntel Skylake-Client-v4 CPU. kholia/OSX-KVM is cloned only for fetch-macOS-v2.py (the
+# Apple recovery download).
 #
 # STAGE controls how far we go (the macOS install has no autounattend, so it is
 # the iterated R&D spike — driven via the Action with retries):
@@ -25,6 +27,11 @@ OSX_KVM_REPO=${OSX_KVM_REPO:-"https://github.com/kholia/OSX-KVM.git"}
 MACOS_SHORTNAME=${MACOS_SHORTNAME:-"tahoe"}   # fetch-macOS-v2.py --shortname (non-interactive; tahoe = macOS 26)
 OSK="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
 
+OPENCORE_QCOW2="$WORKDIR/OpenCore.qcow2"          # LongQT OpenCore, baked by lib-firmware.sh
+OVMF_CODE=${OVMF_CODE:-/usr/share/OVMF/OVMF_CODE_4M.fd}
+OVMF_VARS_SRC=${OVMF_VARS_SRC:-/usr/share/OVMF/OVMF_VARS_4M.fd}
+OVMF_VARS="$WORKDIR/OVMF_VARS.fd"                 # per-build writable copy of the apt VARS template
+
 QCOW2_NAME=${QCOW2_NAME:-"macos-tahoe-26.qcow2"}
 DISK_SIZE=${DISK_SIZE:-80G}
 CPUS=${CPUS:-4}
@@ -43,6 +50,10 @@ QEMU_PID=""
 mkdir -p "$WORKDIR" "$ARTIFACT_DIR"
 
 log() { printf '[build-macos] %s\n' "$*"; }
+
+# shellcheck source=scripts/lib-firmware.sh
+source "$ROOT_DIR/scripts/lib-firmware.sh"
+
 cleanup() {
   set +e
   [[ -n "$QEMU_PID" ]] && kill "$QEMU_PID" 2>/dev/null
@@ -102,9 +113,14 @@ screendump() {  # screendump <label> — via QMP, not HMP: the monitor `screendu
   fi
 }
 
-setup_osx_kvm() {
+setup_osx_kvm() {  # clone kholia/OSX-KVM — used ONLY for fetch-macOS-v2.py (Apple recovery download)
   [[ -d "$OSX_KVM_DIR" ]] || git clone --depth 1 "$OSX_KVM_REPO" "$OSX_KVM_DIR"
   python3 -m pip install --quiet --user requests click 2>/dev/null || true
+}
+
+prepare_firmware() {  # bake the production LongQT OpenCore + stage a writable OVMF_VARS from apt ovmf
+  [[ -f "$OPENCORE_QCOW2" ]] || bake_opencore_qcow2 "$OPENCORE_QCOW2"
+  [[ -f "$OVMF_VARS" ]] || cp "$OVMF_VARS_SRC" "$OVMF_VARS"
 }
 
 fetch_recovery() {
@@ -116,14 +132,13 @@ fetch_recovery() {
     dmg2img -i BaseSystem.dmg BaseSystem.img
   fi
   [[ -f "$QCOW2_NAME" ]] || qemu-img create -f qcow2 "$QCOW2_NAME" "$DISK_SIZE"
-  [[ -f OVMF_VARS.fd ]] || cp OVMF_VARS-1920x1080.fd OVMF_VARS.fd
 }
 
 configure_opencore() {  # patch OpenCore config.plist; arg "hide" => HideAuxiliary+short Timeout so it auto-boots the installed macOS
   local hide="${1:-}"
-  local oc="$OSX_KVM_DIR/OpenCore/OpenCore.qcow2"
+  local oc="$OPENCORE_QCOW2"
   [[ -f "$oc" ]] || { log "OpenCore.qcow2 missing; skip OC patch"; return 0; }
-  log "patching OpenCore config.plist: RequestBootVarRouting=true + Timeout (qemu-nbd)"
+  log "patching OpenCore config.plist: RequestBootVarRouting + 1920x1080 + Timeout (qemu-nbd)"
   sudo modprobe nbd max_part=8 2>/dev/null || { log "no nbd module; skip OC patch"; return 0; }
   sudo qemu-nbd --connect=/dev/nbd0 -f qcow2 "$oc" 2>/dev/null || { log "qemu-nbd connect failed; skip"; return 0; }
   sleep 3
@@ -137,11 +152,16 @@ configure_opencore() {  # patch OpenCore config.plist; arg "hide" => HideAuxilia
     local cfg
     cfg=$(sudo find /mnt/oc -iname config.plist 2>/dev/null | head -1)
     if [[ -n "$cfg" ]]; then
+      # Force UEFI>Output>Resolution=1920x1080. Production reuses OSX-KVM's OVMF_VARS-1920x1080.fd,
+      # which pre-bakes that GOP mode; apt's stock OVMF_VARS_4M.fd boots at the default resolution, so
+      # the OCR click-through coordinates (fixed pixel positions) would land on the wrong controls.
+      # Setting it in config.plist reproduces the 1920x1080 framebuffer the OCR machinery expects.
       sudo HIDE="$hide" python3 - "$cfg" <<'PY' || true
 import plistlib, os, sys
 p = sys.argv[1]
 d = plistlib.load(open(p, "rb"))
 d.setdefault("Booter", {}).setdefault("Quirks", {})["RequestBootVarRouting"] = True
+d.setdefault("UEFI", {}).setdefault("Output", {})["Resolution"] = "1920x1080"
 b = d.setdefault("Misc", {}).setdefault("Boot", {})
 if os.environ.get("HIDE") == "hide":
     b["HideAuxiliary"] = True   # hide EFI/recovery -> only the installed macOS remains
@@ -166,16 +186,16 @@ launch_qemu() {
   log "launching QEMU headless (VNC 127.0.0.1:590$VNC_DISP, ssh :$SSH_PORT, monitor $MON_SOCK)"
   local args=(
     -enable-kvm -m "$MEMORY"
-    -cpu Skylake-Client,-hle,-rtm,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check
+    -cpu Skylake-Client-v4,vendor=GenuineIntel,kvm=on
     -machine q35
     -smp "$CPUS",cores=2,sockets=1
     -device qemu-xhci,id=xhci -device usb-kbd,bus=xhci.0 -device usb-tablet,bus=xhci.0
     -device isa-applesmc,osk="$OSK"
-    -drive if=pflash,format=raw,readonly=on,file=OVMF_CODE_4M.fd
-    -drive if=pflash,format=raw,file=OVMF_VARS.fd
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE"
+    -drive if=pflash,format=raw,file="$OVMF_VARS"
     -smbios type=2
     -device ich9-ahci,id=sata
-    -drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file=OpenCore/OpenCore.qcow2
+    -drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file="$OPENCORE_QCOW2"
     -device ide-hd,bus=sata.2,drive=OpenCoreBoot
     -drive id=MacHDD,if=none,file="$QCOW2_NAME",format=qcow2,discard=unmap,detect-zeroes=unmap
     -device ide-hd,bus=sata.4,drive=MacHDD
@@ -312,7 +332,6 @@ pull_image() {  # oras pull $GHCR_REPO:$1 -> $QCOW2_NAME (the boot disk; skips t
   oras pull "$GHCR_REPO:$1" -o .
   [[ -f "$QCOW2_NAME" ]] || { log "FATAL: image $QCOW2_NAME not pulled from :$1"; exit 1; }
   log "image present: $(du -h "$QCOW2_NAME" | cut -f1)"
-  [[ -f OVMF_VARS.fd ]] || cp OVMF_VARS-1920x1080.fd OVMF_VARS.fd
 }
 
 boot_installed() {  # OpenCore picker -> installed macOS (2nd entry, right of EFI) -> Setup Assistant
@@ -521,6 +540,7 @@ stage_slim() {  # SA-INDEPENDENT slim: boot, reclaim stale clusters over SSH, re
 main() {
   require_kvm
   setup_osx_kvm
+  prepare_firmware   # bake LongQT OpenCore + stage OVMF_VARS before any launch/configure_opencore
   case "$STAGE" in
     boot)
       fetch_recovery; launch_qemu; stage_boot ;;

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -11,11 +11,12 @@ set -euo pipefail
 
 STATE_DIR="${COCOON_MACOS_HOME:-/var/lib/cocoon-macos}"
 FW="$STATE_DIR/firmware"
-LONGQT_VER="${LONGQT_VER:-v0.7}"
-ISO_URL="https://github.com/LongQT-sea/OpenCore-ISO/releases/download/${LONGQT_VER}/LongQT-OpenCore-${LONGQT_VER}.iso"
 
 log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31mFAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# shellcheck source=scripts/lib-firmware.sh
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib-firmware.sh"
 
 [ "$(id -u)" = 0 ] || die "run as root: sudo scripts/doctor.sh (it installs packages and writes $STATE_DIR)"
 
@@ -53,48 +54,7 @@ log "installing OVMF (4M build)"
 cp -f /usr/share/OVMF/OVMF_CODE_4M.fd "$FW/OVMF_CODE.fd"
 cp -f /usr/share/OVMF/OVMF_VARS_4M.fd "$FW/OVMF_VARS.fd"
 
-tmp="$(mktemp -d)"
-nbd="" esp="" iso=""
-cleanup() {
-	[ -n "$esp" ] && umount "$esp" 2>/dev/null || true
-	[ -n "$iso" ] && umount "$iso" 2>/dev/null || true
-	[ -n "$nbd" ] && qemu-nbd --disconnect "$nbd" >/dev/null 2>&1 || true
-	rm -rf "$tmp"
-}
-trap cleanup EXIT
-
-log "downloading LongQT OpenCore $LONGQT_VER"
-curl -fsSL -o "$tmp/oc.iso" "$ISO_URL"
-
-# Bake the loader into a GPT+ESP qcow2: OpenCore must be a writable disk so a per-VM overlay can
-# inject a unique SMBIOS; the LongQT loader ships only as an ISO, so copy its EFI onto a fresh ESP.
-log "baking OpenCore.qcow2"
-oc="$FW/OpenCore.qcow2"
-qemu-img create -f qcow2 "$oc" 384M >/dev/null
-for i in $(seq 0 15); do
-	if [ -e "/dev/nbd$i" ] && [ ! -e "/sys/block/nbd$i/pid" ]; then nbd="/dev/nbd$i"; break; fi
-done
-[ -n "$nbd" ] || die "no free /dev/nbd device"
-qemu-nbd --connect="$nbd" -f qcow2 "$oc"
-# qemu-nbd registers the block device asynchronously; wait for its size before partitioning.
-for _ in $(seq 50); do [ "$(blockdev --getsize64 "$nbd" 2>/dev/null || echo 0)" -gt 0 ] && break; sleep 0.1; done
-sgdisk -Z "$nbd" >/dev/null
-sgdisk -n 1:0:0 -t 1:ef00 -c 1:EFI "$nbd" >/dev/null
-partprobe "$nbd" 2>/dev/null || true
-for _ in $(seq 50); do [ -e "${nbd}p1" ] && break; partprobe "$nbd" 2>/dev/null || true; sleep 0.1; done
-mkfs.fat -F32 "${nbd}p1" >/dev/null
-esp="$tmp/esp" iso="$tmp/iso"
-mkdir -p "$esp" "$iso"
-mount "${nbd}p1" "$esp"
-mount -o loop,ro "$tmp/oc.iso" "$iso"
-cp -r "$iso/EFI_RELEASE/EFI" "$esp/"
-sync
-umount "$esp"
-esp=""
-umount "$iso"
-iso=""
-qemu-nbd --disconnect "$nbd"
-nbd=""
+bake_opencore_qcow2 "$FW/OpenCore.qcow2"
 
 log "✅ host ready — firmware in $FW"
 log "next: cocoon-macos image pull ghcr.io/cocoonstack/cocoon-macos/tahoe:26"

--- a/scripts/lib-firmware.sh
+++ b/scripts/lib-firmware.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# cocoon-macos firmware library — bakes the validated LongQT OpenCore loader into a bootable
+# GPT+ESP qcow2. Sourced by both scripts/doctor.sh (host provisioning) and scripts/build-qemu-macos.sh
+# (CI image build) so both boot the exact same OpenCore stack. Override the loader version with
+# LONGQT_VER=vX.Y.
+#
+# Callers must provide a `log` function and be able to run qemu-img/qemu-nbd/sgdisk/mkfs.fat/curl plus
+# load the nbd module. Privileged steps go through $SUDO, so this works whether the caller is already
+# root (doctor) or an unprivileged user with passwordless sudo (the CI runner).
+
+LONGQT_VER="${LONGQT_VER:-v0.7}"
+
+# doctor runs as root (SUDO empty, identical to its previous inline behavior); the CI build runs
+# unprivileged and needs sudo for the nbd/mount/mkfs steps.
+if [ "$(id -u)" = 0 ]; then SUDO=""; else SUDO="sudo"; fi
+
+# bake_opencore_qcow2 OUT_QCOW2 — download the LongQT OpenCore ISO and copy its EFI onto a fresh
+# GPT+ESP FAT32 qcow2 at OUT_QCOW2.
+#
+# OpenCore must be a writable disk so a per-VM overlay can inject a unique SMBIOS; the LongQT loader
+# ships only as an ISO, so copy its EFI onto a fresh ESP. Runs the whole bake in a subshell so its
+# EXIT-trap cleanup is scoped here and never clobbers the caller's own trap.
+bake_opencore_qcow2() {
+	local out="$1"
+	local url="https://github.com/LongQT-sea/OpenCore-ISO/releases/download/${LONGQT_VER}/LongQT-OpenCore-${LONGQT_VER}.iso"
+	$SUDO modprobe nbd max_part=8 2>/dev/null || true
+	(
+		local tmp nbd="" esp="" iso=""
+		tmp="$(mktemp -d)"
+		# shellcheck disable=SC2329  # invoked indirectly via the trap below
+		cleanup() {
+			[ -n "$esp" ] && $SUDO umount "$esp" 2>/dev/null || true
+			[ -n "$iso" ] && $SUDO umount "$iso" 2>/dev/null || true
+			[ -n "$nbd" ] && $SUDO qemu-nbd --disconnect "$nbd" >/dev/null 2>&1 || true
+			rm -rf "$tmp"
+		}
+		trap cleanup EXIT
+
+		log "downloading LongQT OpenCore $LONGQT_VER"
+		curl -fsSL -o "$tmp/oc.iso" "$url"
+
+		log "baking OpenCore.qcow2"
+		qemu-img create -f qcow2 "$out" 384M >/dev/null
+		local i
+		for i in $(seq 0 15); do
+			if [ -e "/dev/nbd$i" ] && [ ! -e "/sys/block/nbd$i/pid" ]; then nbd="/dev/nbd$i"; break; fi
+		done
+		[ -n "$nbd" ] || { echo "no free /dev/nbd device" >&2; exit 1; }
+		$SUDO qemu-nbd --connect="$nbd" -f qcow2 "$out"
+		# qemu-nbd registers the block device asynchronously; wait for its size before partitioning.
+		for _ in $(seq 50); do [ "$($SUDO blockdev --getsize64 "$nbd" 2>/dev/null || echo 0)" -gt 0 ] && break; sleep 0.1; done
+		$SUDO sgdisk -Z "$nbd" >/dev/null
+		$SUDO sgdisk -n 1:0:0 -t 1:ef00 -c 1:EFI "$nbd" >/dev/null
+		$SUDO partprobe "$nbd" 2>/dev/null || true
+		for _ in $(seq 50); do [ -e "${nbd}p1" ] && break; $SUDO partprobe "$nbd" 2>/dev/null || true; sleep 0.1; done
+		$SUDO mkfs.fat -F32 "${nbd}p1" >/dev/null
+		esp="$tmp/esp" iso="$tmp/iso"
+		mkdir -p "$esp" "$iso"
+		$SUDO mount "${nbd}p1" "$esp"
+		$SUDO mount -o loop,ro "$tmp/oc.iso" "$iso"
+		$SUDO cp -r "$iso/EFI_RELEASE/EFI" "$esp/"
+		sync
+	)
+}


### PR DESCRIPTION
## What changed

The CI image-build pipeline now boots the **exact same firmware stack production uses** (doctor.sh + the Go CLI): LongQT OpenCore, apt `ovmf` 4M firmware, and a single `Skylake-Client-v4,vendor=GenuineIntel,kvm=on` CPU.

- **New `scripts/lib-firmware.sh`** — extracts the validated ISO-download + qemu-nbd bake from `doctor.sh` into a self-contained `bake_opencore_qcow2 OUT_QCOW2` (downloads the LongQT ISO, `LONGQT_VER` default `v0.7`, 384M qcow2, GPT+ESP via sgdisk, `mkfs.fat -F32`, copies `EFI_RELEASE/EFI`, with the blockdev-size + partition readiness waits and its own subshell-scoped temp-dir/trap cleanup). Privileged steps go through `$SUDO` so it works whether the caller is root (doctor) or an unprivileged CI runner with passwordless sudo.
- **`scripts/doctor.sh`** — now sources the lib and calls `bake_opencore_qcow2`; observable behavior (log lines, idempotency check, exit codes, root/deps/nbd checks) is unchanged.
- **`scripts/build-qemu-macos.sh`** —
  - OpenCore is baked into the workdir via the lib; every `$OSX_KVM_DIR/OpenCore/OpenCore.qcow2` reference (boot/install/setup/slim/verify + `configure_opencore`) now points at the baked file. The qemu-nbd `config.plist` patch stays, applied to the baked image.
  - OVMF now comes from apt: `/usr/share/OVMF/OVMF_CODE_4M.fd` (read-only pflash) + a per-build writable copy of `OVMF_VARS_4M.fd`. OSX-KVM OVMF copies dropped.
  - `-cpu` replaced with exactly `Skylake-Client-v4,vendor=GenuineIntel,kvm=on`.
  - kholia/OSX-KVM is now cloned **only** for `fetch-macOS-v2.py` (recovery download); header comment updated.
- **`.github/workflows/build-macos-image.yml`** — added `ovmf gdisk dosfstools parted` to the apt install list (the bake now runs in CI and needs sgdisk/mkfs.fat/partprobe + the OVMF firmware).
- **`README.md`** — the "CI image pipeline" section now describes the LongQT + unified-CPU recipe and that CI boots the exact same firmware stack production uses.

## Why one stack matters

Production already runs LongQT OpenCore; the OSX-KVM OpenCore **does not boot on AMD Zen5**, so the old pipeline validated golden images against a loader the hosts never run. Baking the same LongQT firmware in CI means an image that passes CI boots identically on the Intel/AMD hosts the CLI targets.

## Display-resolution preservation

OSX-KVM's `OVMF_VARS-1920x1080.fd` pre-bakes a 1920x1080 GOP mode that the OCR click-through coordinates (fixed pixel positions) depend on; stock `OVMF_VARS_4M.fd` boots at the default resolution. To compensate, `configure_opencore`'s plist patch now also sets `UEFI>Output>Resolution="1920x1080"`. Verified against the LongQT v0.7 RELEASE `config.plist`: its `UEFI>Output` already has `ProvideConsoleGop=True` and `Resolution=""`, so the patch touches only `Resolution` (all other Output keys preserved) and will take effect. A WHY comment documents this at the patch site.

## Validation

- `bash -n` on all three scripts: pass.
- `shellcheck -x` on `lib-firmware.sh` + `doctor.sh`: clean. `build-qemu-macos.sh` has only pre-existing findings (SC2054/SC2034/SC2086/SC2015, identical set to `origin/master`), none introduced here; the `$SUDO` idiom is deliberately unquoted.
- Grep confirms no leftover OSX-KVM OpenCore/OVMF references in the build script (remaining OSX-KVM uses are the `fetch-macOS-v2.py` clone + the recovery/disk workdir only).
- Go gate (no `.go` files changed, run as a sanity no-op): `gofumpt -l .` clean, `go build` (darwin+linux) OK, `golangci-lint` (darwin+linux) 0 issues, `go test -race` OK.
- **A real `workflow_dispatch` run is the follow-up validation and is still pending** — no workflow was triggered as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)