### PR TITLE
feat(vm): data disks via --data-disk, aligned with cocoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,20 @@ cocoon-macos vm run <IMAGE> --net tap    --tap tap0       …               # us
 cocoon-macos vm snapshot m1 --tag clean
 cocoon-macos vm restore  m1 --tag clean          # --force to stop+restore+relaunch a running VM
 cocoon-macos vm clone    m1 -n m2 --ssh-port 2223 --random-smbios
+
+# extra data disks — repeatable --data-disk with comma-separated key=value (mirrors cocoon's flag):
+cocoon-macos vm run <IMAGE> --data-disk size=20G --data-disk name=scratch,size=50G   # up to 4
 ```
+
+`--data-disk` (on `run`/`create`/`clone`) attaches empty qcow2 data disks. Keys: `size=` (required,
+`units.RAMInBytes` syntax e.g. `20G`, min 16MiB) and `name=` (optional, `[a-z][a-z0-9_-]{0,19}`,
+default `data0`, `data1`, …; duplicates error). **At most 4 disks:** macOS has no virtio-blk driver
+(the OS disk itself rides AHCI), so data disks take the `ich9-ahci` controller's remaining SATA
+ports — `OpenCoreBoot` (sata.2) and `MacHDD` (sata.4) leave exactly ports 0, 1, 3, 5 free. They
+snapshot/restore and clone with the VM (clone copies SRC's disks and can add more). **Unlike cocoon,
+`fstype=`/`mount=`/`directio=` are rejected**: a macOS guest has no cloud-init/agent to partition,
+format, or mount the disk — it is attached raw, so **format it in the guest** (Disk Utility or
+`diskutil`).
 
 `vm run` does: `qemu-img create -b <golden> overlay.qcow2` (instant CoW clone) → copy a
 per-VM `OVMF_VARS` → launch `qemu-system-x86_64` (recipe in `qemu/launch.go`: a `Skylake-Client-v4`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cocoon-macos vm run <IMAGE> --data-disk size=20G --data-disk name=scratch,size=5
 
 `--data-disk` (on `run`/`create`/`clone`) attaches empty qcow2 data disks. Keys: `size=` (required,
 `units.RAMInBytes` syntax e.g. `20G`, min 16MiB) and `name=` (optional, `[a-z][a-z0-9_-]{0,19}`,
-default `data0`, `data1`, …; duplicates error). **At most 4 disks:** macOS has no virtio-blk driver
+default `data1`, `data2`, … (cocoon's auto-naming); duplicates error). **At most 4 disks:** macOS has no virtio-blk driver
 (the OS disk itself rides AHCI), so data disks take the `ich9-ahci` controller's remaining SATA
 ports — `OpenCoreBoot` (sata.2) and `MacHDD` (sata.4) leave exactly ports 0, 1, 3, 5 free. They
 snapshot/restore and clone with the VM (clone copies SRC's disks and can add more). **Unlike cocoon,

--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -26,15 +26,35 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if name == "" {
 		name = src + "-clone-" + time.Now().Format("150405")
 	}
+	// the clone inherits SRC's data disks by name; extra --data-disk specs must not collide with them
+	// and the combined count still honors the AHCI cap. Parse before scaffolding to fail fast.
+	reserved := make([]string, len(srcRec.DataDisks))
+	for i, p := range srcRec.DataDisks {
+		reserved[i] = dataDiskName(p)
+	}
+	rawDisks, _ := cmd.Flags().GetStringArray("data-disk")
+	diskSpecs, err := parseDataDisks(rawDisks, reserved)
+	if err != nil {
+		return err
+	}
 	dir, overlay, ovmfVars, digest, err := scaffoldVM(cmd, name, srcRec.Image, srcRec.OVMFVars, filepath.Base(srcRec.OVMFVars))
 	if err != nil {
 		return err
 	}
 	ctx := home.Ctx(cmd)
+	copied, err := copyDataDisks(dir, srcRec.DataDisks)
+	if err != nil {
+		return err
+	}
+	newDisks, err := createDataDisks(ctx, dir, diskSpecs)
+	if err != nil {
+		return err
+	}
 	r := &record{
 		Name: name, Image: srcRec.Image, ImageDigest: digest, Disk: overlay,
 		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: srcRec.CPUs, Memory: srcRec.Memory,
-		VMID: utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
+		DataDisks: append(copied, newDisks...),
+		VMID:      utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
 	}
 	if cmd.Flags().Changed("cpus") {
 		r.CPUs, _ = cmd.Flags().GetInt("cpus")

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -123,6 +123,7 @@ func addVMFlags(cmd *cobra.Command) {
 	cmd.Flags().Int("cpus", 4, "vCPU count")
 	cmd.Flags().String("memory", "8192", "guest memory in MiB")
 	cmd.Flags().Bool("hugepages", false, "back guest RAM with 2 MiB hugepages (needs host hugepages reserved; lower TLB/EPT overhead)")
+	cmd.Flags().StringArray("data-disk", nil, "attach an extra qcow2 data disk: comma-separated key=value (size= required e.g. size=20G; name= optional, default dataN). Repeatable, max 4. macOS has no in-guest agent, so fstype=/mount= are unsupported — format it in the guest (Disk Utility/diskutil)")
 	cmd.Flags().Int("vnc", -1, "VNC display number (n => host 127.0.0.1:590n); <0 disables")
 	cmd.Flags().Int("ssh-port", 0, "host port forwarded to guest :22; 0 disables")
 	cmd.Flags().String("opencore", "", "OpenCore.qcow2 boot loader (default: <state-dir>/firmware/OpenCore.qcow2; provisioned by scripts/doctor.sh)")

--- a/cmd/vm/datadisk.go
+++ b/cmd/vm/datadisk.go
@@ -1,0 +1,152 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+
+	"github.com/cocoonstack/cocoon/types"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+const (
+	// minDataDiskSize mirrors cocoon's hypervisor.MinDataDiskSize (16 MiB); a local const because
+	// that package drags in storage/metering/backend (net/http, os/exec) and isn't dependency-light.
+	minDataDiskSize int64 = 16 << 20
+
+	// maxDataDisks caps data disks at 4. WHY: macOS has no virtio-blk driver (see qemu/launch.go),
+	// so disks ride the single ich9-ahci controller's 6 SATA ports; OpenCoreBoot=sata.2 and
+	// MacHDD=sata.4 leave ports 0,1,3,5 — exactly four free.
+	maxDataDisks = 4
+)
+
+// parseDataDisks parses every --data-disk arg into a DataDiskSpec, fills default names
+// (data0, data1, …), rejects duplicate names, and caps the total at maxDataDisks. reserved names
+// (a clone's copied disks) count against both the duplicate check and the AHCI cap.
+func parseDataDisks(raw, reserved []string) ([]types.DataDiskSpec, error) {
+	used := make(map[string]bool, len(reserved))
+	for _, n := range reserved {
+		used[n] = true
+	}
+	specs := make([]types.DataDiskSpec, 0, len(raw))
+	for _, s := range raw {
+		spec, err := parseDataDiskSpec(s)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+	}
+	// claim explicit names first, so an auto name never steals one a later spec asked for
+	for _, s := range specs {
+		if s.Name == "" {
+			continue
+		}
+		if used[s.Name] {
+			return nil, fmt.Errorf("data disk: name %q duplicated", s.Name)
+		}
+		used[s.Name] = true
+	}
+	autoIdx := 0
+	for i := range specs {
+		if specs[i].Name != "" {
+			continue
+		}
+		for {
+			candidate := fmt.Sprintf("data%d", autoIdx)
+			autoIdx++
+			if !used[candidate] {
+				specs[i].Name, used[candidate] = candidate, true
+				break
+			}
+		}
+	}
+	if total := len(reserved) + len(specs); total > maxDataDisks {
+		return nil, fmt.Errorf("data disk: %d disks exceeds the %d-disk limit (macOS has no virtio-blk driver; disks ride the ich9-ahci controller's free SATA ports 0,1,3,5)", total, maxDataDisks)
+	}
+	return specs, nil
+}
+
+// parseDataDiskSpec parses one comma-separated --data-disk arg. size= is required (≥16MiB); name= is
+// optional. fstype=/mount=/directio= are rejected: macOS guests have no cloud-init/agent to format
+// or mount a disk (cocoon's Linux path does) — the disk is attached raw to be formatted in-guest.
+func parseDataDiskSpec(s string) (types.DataDiskSpec, error) {
+	var spec types.DataDiskSpec
+	if s == "" {
+		return spec, fmt.Errorf("data disk: empty spec")
+	}
+	for part := range strings.SplitSeq(s, ",") {
+		rawKey, rawVal, ok := strings.Cut(part, "=")
+		if !ok {
+			return spec, fmt.Errorf("data disk: %q is not key=value", part)
+		}
+		key, val := strings.TrimSpace(rawKey), strings.TrimSpace(rawVal)
+		switch key {
+		case "size":
+			n, err := units.RAMInBytes(val)
+			if err != nil {
+				return spec, fmt.Errorf("data disk: invalid size %q: %w", val, err)
+			}
+			if n < minDataDiskSize {
+				return spec, fmt.Errorf("data disk: size %s below 16MiB minimum", val)
+			}
+			spec.Size = n
+		case "name":
+			if !types.ValidDataDiskName(val) {
+				return spec, fmt.Errorf("data disk: invalid name %q (must match [a-z][a-z0-9_-]{0,19}, no cocoon- prefix)", val)
+			}
+			spec.Name = val
+		case "fstype", "mount", "directio":
+			// intentional macOS divergence from cocoon: no in-guest agent to format/mount a disk, so the
+			// disk is attached raw — format it in the guest with Disk Utility/diskutil.
+			return spec, fmt.Errorf("data disk: key %q unsupported on macOS (no in-guest agent; format the disk in the guest with Disk Utility/diskutil)", key)
+		default:
+			return spec, fmt.Errorf("data disk: unknown key %q", key)
+		}
+	}
+	if spec.Size == 0 {
+		return spec, fmt.Errorf("data disk: size= required")
+	}
+	return spec, nil
+}
+
+// createDataDisks provisions each parsed spec as an empty qcow2 under dir and returns their paths.
+func createDataDisks(ctx context.Context, dir string, specs []types.DataDiskSpec) ([]string, error) {
+	paths := make([]string, 0, len(specs))
+	for _, s := range specs {
+		path := dataDiskPath(dir, s.Name)
+		// size as a plain byte count; qemu-img create takes an integer size in bytes
+		if err := utils.RunQemuImg(ctx, "create", "-f", "qcow2", path, strconv.FormatInt(s.Size, 10)); err != nil {
+			return nil, fmt.Errorf("create data disk %s: %w", s.Name, err)
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+// copyDataDisks reflink-copies SRC's data disks into dir keeping their basenames, so both the disk
+// names and their qcow2 contents carry over to a clone; it returns the new paths.
+func copyDataDisks(dir string, src []string) ([]string, error) {
+	paths := make([]string, 0, len(src))
+	for _, srcPath := range src {
+		dst := filepath.Join(dir, filepath.Base(srcPath))
+		if err := utils.ReflinkCopy(dst, srcPath); err != nil {
+			return nil, fmt.Errorf("copy data disk %s: %w", filepath.Base(srcPath), err)
+		}
+		paths = append(paths, dst)
+	}
+	return paths, nil
+}
+
+// dataDiskPath is the on-disk path of a data disk given the VM dir and disk name.
+func dataDiskPath(dir, name string) string {
+	return filepath.Join(dir, "data-"+name+".qcow2")
+}
+
+// dataDiskName recovers a data disk's name from its dataDiskPath (data-<name>.qcow2).
+func dataDiskName(path string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "data-"), ".qcow2")
+}

--- a/cmd/vm/datadisk.go
+++ b/cmd/vm/datadisk.go
@@ -25,7 +25,7 @@ const (
 )
 
 // parseDataDisks parses every --data-disk arg into a DataDiskSpec, fills default names
-// (data0, data1, …), rejects duplicate names, and caps the total at maxDataDisks. reserved names
+// (data1, data2, … — same 1-based auto-naming as cocoon), rejects duplicate names, and caps the total at maxDataDisks. reserved names
 // (a clone's copied disks) count against both the duplicate check and the AHCI cap.
 func parseDataDisks(raw, reserved []string) ([]types.DataDiskSpec, error) {
 	used := make(map[string]bool, len(reserved))
@@ -50,7 +50,7 @@ func parseDataDisks(raw, reserved []string) ([]types.DataDiskSpec, error) {
 		}
 		used[s.Name] = true
 	}
-	autoIdx := 0
+	autoIdx := 1
 	for i := range specs {
 		if specs[i].Name != "" {
 			continue

--- a/cmd/vm/datadisk_test.go
+++ b/cmd/vm/datadisk_test.go
@@ -15,12 +15,12 @@ func TestParseDataDisks(t *testing.T) {
 		wantNames []string
 		wantSizes []int64
 	}{
-		{name: "single default name", raw: []string{"size=1G"}, wantNames: []string{"data0"}, wantSizes: []int64{gib}},
+		{name: "single default name", raw: []string{"size=1G"}, wantNames: []string{"data1"}, wantSizes: []int64{gib}},
 		{name: "explicit name", raw: []string{"name=logs,size=512M"}, wantNames: []string{"logs"}, wantSizes: []int64{512 << 20}},
-		{name: "multiple default names count up", raw: []string{"size=1G", "size=2G"}, wantNames: []string{"data0", "data1"}, wantSizes: []int64{gib, 2 * gib}},
-		{name: "auto name skips an explicit one", raw: []string{"name=data0,size=1G", "size=1G"}, wantNames: []string{"data0", "data1"}, wantSizes: []int64{gib, gib}},
-		{name: "size at 16MiB minimum", raw: []string{"size=16M"}, wantNames: []string{"data0"}, wantSizes: []int64{16 << 20}},
-		{name: "four disks is the cap", raw: []string{"size=1G", "size=1G", "size=1G", "size=1G"}, wantNames: []string{"data0", "data1", "data2", "data3"}, wantSizes: []int64{gib, gib, gib, gib}},
+		{name: "multiple default names count up", raw: []string{"size=1G", "size=2G"}, wantNames: []string{"data1", "data2"}, wantSizes: []int64{gib, 2 * gib}},
+		{name: "auto name skips an explicit one", raw: []string{"name=data1,size=1G", "size=1G"}, wantNames: []string{"data1", "data2"}, wantSizes: []int64{gib, gib}},
+		{name: "size at 16MiB minimum", raw: []string{"size=16M"}, wantNames: []string{"data1"}, wantSizes: []int64{16 << 20}},
+		{name: "four disks is the cap", raw: []string{"size=1G", "size=1G", "size=1G", "size=1G"}, wantNames: []string{"data1", "data2", "data3", "data4"}, wantSizes: []int64{gib, gib, gib, gib}},
 
 		{name: "empty spec", raw: []string{""}, wantErr: true},
 		{name: "missing size", raw: []string{"name=foo"}, wantErr: true},
@@ -37,9 +37,9 @@ func TestParseDataDisks(t *testing.T) {
 		{name: "over the four-disk cap", raw: []string{"size=1G", "size=1G", "size=1G", "size=1G", "size=1G"}, wantErr: true},
 
 		// clone reserves the copied disks' names: collisions error and reserved count against the cap
-		{name: "collides with a reserved name", raw: []string{"name=data0,size=1G"}, reserved: []string{"data0"}, wantErr: true},
-		{name: "auto name skips reserved", raw: []string{"size=1G"}, reserved: []string{"data0"}, wantNames: []string{"data1"}, wantSizes: []int64{gib}},
-		{name: "reserved fills the cap", raw: []string{"size=1G", "size=1G"}, reserved: []string{"data0", "data1", "data2"}, wantErr: true},
+		{name: "collides with a reserved name", raw: []string{"name=data1,size=1G"}, reserved: []string{"data1"}, wantErr: true},
+		{name: "auto name skips reserved", raw: []string{"size=1G"}, reserved: []string{"data1"}, wantNames: []string{"data2"}, wantSizes: []int64{gib}},
+		{name: "reserved fills the cap", raw: []string{"size=1G", "size=1G"}, reserved: []string{"data1", "data2", "data3"}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestParseDataDisks(t *testing.T) {
 
 func TestDataDiskNameRoundTrip(t *testing.T) {
 	// clone recovers reserved names from the copied disks' paths, so this must invert dataDiskPath
-	for _, name := range []string{"data0", "logs", "a-b_c"} {
+	for _, name := range []string{"data1", "logs", "a-b_c"} {
 		if got := dataDiskName(dataDiskPath("/vm/dir", name)); got != name {
 			t.Errorf("dataDiskName(dataDiskPath(%q)) = %q", name, got)
 		}

--- a/cmd/vm/datadisk_test.go
+++ b/cmd/vm/datadisk_test.go
@@ -1,0 +1,78 @@
+package vm
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseDataDisks(t *testing.T) {
+	const gib = 1 << 30
+	tests := []struct {
+		name      string
+		raw       []string
+		reserved  []string
+		wantErr   bool
+		wantNames []string
+		wantSizes []int64
+	}{
+		{name: "single default name", raw: []string{"size=1G"}, wantNames: []string{"data0"}, wantSizes: []int64{gib}},
+		{name: "explicit name", raw: []string{"name=logs,size=512M"}, wantNames: []string{"logs"}, wantSizes: []int64{512 << 20}},
+		{name: "multiple default names count up", raw: []string{"size=1G", "size=2G"}, wantNames: []string{"data0", "data1"}, wantSizes: []int64{gib, 2 * gib}},
+		{name: "auto name skips an explicit one", raw: []string{"name=data0,size=1G", "size=1G"}, wantNames: []string{"data0", "data1"}, wantSizes: []int64{gib, gib}},
+		{name: "size at 16MiB minimum", raw: []string{"size=16M"}, wantNames: []string{"data0"}, wantSizes: []int64{16 << 20}},
+		{name: "four disks is the cap", raw: []string{"size=1G", "size=1G", "size=1G", "size=1G"}, wantNames: []string{"data0", "data1", "data2", "data3"}, wantSizes: []int64{gib, gib, gib, gib}},
+
+		{name: "empty spec", raw: []string{""}, wantErr: true},
+		{name: "missing size", raw: []string{"name=foo"}, wantErr: true},
+		{name: "size below minimum", raw: []string{"size=1M"}, wantErr: true},
+		{name: "size not parseable", raw: []string{"size=notabyte"}, wantErr: true},
+		{name: "not key=value", raw: []string{"size"}, wantErr: true},
+		{name: "bad name uppercase", raw: []string{"name=Bad,size=1G"}, wantErr: true},
+		{name: "bad name cocoon prefix", raw: []string{"name=cocoon-x,size=1G"}, wantErr: true},
+		{name: "duplicate name", raw: []string{"name=x,size=1G", "name=x,size=1G"}, wantErr: true},
+		{name: "unknown key", raw: []string{"size=1G,color=red"}, wantErr: true},
+		{name: "fstype rejected on macOS", raw: []string{"size=1G,fstype=ext4"}, wantErr: true},
+		{name: "mount rejected on macOS", raw: []string{"size=1G,mount=/mnt/x"}, wantErr: true},
+		{name: "directio rejected on macOS", raw: []string{"size=1G,directio=on"}, wantErr: true},
+		{name: "over the four-disk cap", raw: []string{"size=1G", "size=1G", "size=1G", "size=1G", "size=1G"}, wantErr: true},
+
+		// clone reserves the copied disks' names: collisions error and reserved count against the cap
+		{name: "collides with a reserved name", raw: []string{"name=data0,size=1G"}, reserved: []string{"data0"}, wantErr: true},
+		{name: "auto name skips reserved", raw: []string{"size=1G"}, reserved: []string{"data0"}, wantNames: []string{"data1"}, wantSizes: []int64{gib}},
+		{name: "reserved fills the cap", raw: []string{"size=1G", "size=1G"}, reserved: []string{"data0", "data1", "data2"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specs, err := parseDataDisks(tt.raw, tt.reserved)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got specs %v", specs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDataDisks: %v", err)
+			}
+			gotNames := make([]string, len(specs))
+			gotSizes := make([]int64, len(specs))
+			for i, s := range specs {
+				gotNames[i], gotSizes[i] = s.Name, s.Size
+			}
+			if !slices.Equal(gotNames, tt.wantNames) {
+				t.Errorf("names: got %v, want %v", gotNames, tt.wantNames)
+			}
+			if !slices.Equal(gotSizes, tt.wantSizes) {
+				t.Errorf("sizes: got %v, want %v", gotSizes, tt.wantSizes)
+			}
+		})
+	}
+}
+
+func TestDataDiskNameRoundTrip(t *testing.T) {
+	// clone recovers reserved names from the copied disks' paths, so this must invert dataDiskPath
+	for _, name := range []string{"data0", "logs", "a-b_c"} {
+		if got := dataDiskName(dataDiskPath("/vm/dir", name)); got != name {
+			t.Errorf("dataDiskName(dataDiskPath(%q)) = %q", name, got)
+		}
+	}
+}

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -31,13 +31,14 @@ type record struct {
 	Image       string `json:"image"`
 	ImageDigest string `json:"image_digest,omitempty"`
 
-	CPUs      int    `json:"cpus"`
-	Memory    string `json:"memory"`
-	VNCDisp   int    `json:"vnc"`
-	VNCPass   string `json:"vnc_password,omitempty"`
-	SSHPort   int    `json:"ssh_port"`
-	NetMode   string `json:"net_mode,omitempty"`
-	Hugepages bool   `json:"hugepages,omitempty"`
+	CPUs      int      `json:"cpus"`
+	Memory    string   `json:"memory"`
+	VNCDisp   int      `json:"vnc"`
+	VNCPass   string   `json:"vnc_password,omitempty"`
+	SSHPort   int      `json:"ssh_port"`
+	NetMode   string   `json:"net_mode,omitempty"`
+	Hugepages bool     `json:"hugepages,omitempty"`
+	DataDisks []string `json:"data_disks,omitempty"` // created data-disk qcow2 paths, attached on AHCI ports 0,1,3,5
 
 	Disk         string       `json:"disk"`
 	OpenCore     string       `json:"opencore"`

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -122,6 +122,11 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if name == "" {
 		name = "macos-" + time.Now().Format("20060102-150405")
 	}
+	rawDisks, _ := cmd.Flags().GetStringArray("data-disk")
+	diskSpecs, err := parseDataDisks(rawDisks, nil) // fail fast before any scaffolding
+	if err != nil {
+		return nil, err
+	}
 	oc, code, varsTmpl, err := resolveFirmware(cmd)
 	if err != nil {
 		return nil, err
@@ -143,6 +148,9 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 		Name: name, Image: image, ImageDigest: digest, Disk: overlay, OVMFCode: code, OVMFVars: ovmfVars,
 		CPUs: cpus, Memory: mem, VNCDisp: vnc, SSHPort: ssh, VNCPass: vncPass, NetMode: netMode, Tap: tap, Hugepages: huge,
 		VMID: utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
+	}
+	if r.DataDisks, err = createDataDisks(ctx, dir, diskSpecs); err != nil {
+		return nil, err
 	}
 	// OpenCore before networking: a random SMBIOS sets r.MAC = ROM, which prepareNet keeps as the guest MAC.
 	randomSMBIOS, _ := cmd.Flags().GetBool("random-smbios")
@@ -171,6 +179,7 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 		CPUs: r.CPUs, Memory: r.Memory, VNCDisp: r.VNCDisp, SSHPort: r.SSHPort, MAC: r.MAC, VNCPass: r.VNCPass,
 		Tap:       r.Tap, // set for tap/bridge/cni (a real host TAP); empty => user-mode SLIRP
 		Hugepages: r.Hugepages,
+		DataDisks: r.DataDisks,
 		MonSock:   filepath.Join(dir, "monitor.sock"), QMPSock: filepath.Join(dir, "qmp.sock"),
 	}
 	pidfile := filepath.Join(dir, "qemu.pid")

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -84,12 +84,13 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 }
 
 // imagesToSnapshot lists the qcow2 images that make up a VM snapshot: the disk overlay always,
-// plus OVMF_VARS only if it is qcow2 (raw .fd can't hold internal snapshots, so with a raw NVRAM
-// the firmware vars do NOT roll back — only guest disk state does).
+// the data disks (all qcow2, so they roll back with the OS disk), plus OVMF_VARS only if it is
+// qcow2 (raw .fd can't hold internal snapshots, so with a raw NVRAM the firmware vars do NOT roll
+// back — only guest disk state does).
 func imagesToSnapshot(r *record) []string {
 	imgs := []string{r.Disk}
 	if qemu.IsQcow2NVRAM(r.OVMFVars) {
 		imgs = append(imgs, r.OVMFVars)
 	}
-	return imgs
+	return append(imgs, r.DataDisks...)
 }

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -24,11 +24,12 @@ type Spec struct {
 	Name string
 
 	CPUs      int
-	Memory    string // MiB, e.g. "8192"
-	VNCDisp   int    // n => host 127.0.0.1:590n; <0 disables
-	VNCPass   string // set via the monitor post-launch (macOS Screen Sharing needs password auth)
-	SSHPort   int    // host port forwarded to guest :22; 0 disables
-	Hugepages bool   // needs host hugepages reserved; off => default RAM
+	Memory    string   // MiB, e.g. "8192"
+	VNCDisp   int      // n => host 127.0.0.1:590n; <0 disables
+	VNCPass   string   // set via the monitor post-launch (macOS Screen Sharing needs password auth)
+	SSHPort   int      // host port forwarded to guest :22; 0 disables
+	Hugepages bool     // needs host hugepages reserved; off => default RAM
+	DataDisks []string // extra qcow2 data disks; attached on the AHCI ports MacHDD/OpenCore leave free
 
 	Disk     string
 	OpenCore string
@@ -87,6 +88,19 @@ func (s Spec) Args() []string {
 		"-device", "vmware-svga",
 	}
 	a = append(memBackend, a...) // -object must precede the -machine memory-backend reference
+	// data disks: same AHCI/IDE path and perf tuning as MacHDD (macOS has no virtio-blk). They ride
+	// the SATA ports OpenCoreBoot (sata.2) and MacHDD (sata.4) leave free; the count is capped at 4
+	// upstream so the index never runs past dataDiskPorts.
+	dataDiskPorts := []int{0, 1, 3, 5}
+	for i, path := range s.DataDisks {
+		if i >= len(dataDiskPorts) {
+			break
+		}
+		id := fmt.Sprintf("DataDisk%d", i)
+		a = append(a,
+			"-drive", fmt.Sprintf("id=%s,if=none,format=qcow2,cache=writeback,aio=io_uring,discard=unmap,detect-zeroes=unmap,file=%s", id, path),
+			"-device", fmt.Sprintf("ide-hd,bus=sata.%d,drive=%s", dataDiskPorts[i], id))
+	}
 	switch {
 	case s.Tap != "":
 		// attach to a pre-created host TAP (cocoon's network plane / a bridge owns IP+forwarding);

--- a/qemu/launch_test.go
+++ b/qemu/launch_test.go
@@ -1,6 +1,7 @@
 package qemu
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -84,6 +85,37 @@ func TestArgsDiskTuning(t *testing.T) {
 			strings.Contains(d, "detect-zeroes=unmap")
 	}) {
 		t.Fatalf("MacHDD missing perf tuning: %v", drives)
+	}
+}
+
+func TestArgsDataDisks(t *testing.T) {
+	// four disks exercise the full free-port set; ports skip sata.2 (OpenCoreBoot) and sata.4 (MacHDD)
+	files := []string{"/v/data-a.qcow2", "/v/data-b.qcow2", "/v/data-c.qcow2", "/v/data-d.qcow2"}
+	wantPorts := []int{0, 1, 3, 5}
+	s := Spec{Disk: "/v/d.qcow2", OpenCore: "/v/oc.qcow2", OVMFCode: "/v/c.fd", OVMFVars: "/v/v.fd", CPUs: 2, Memory: "4096", VNCDisp: -1, DataDisks: files}
+	drives := argVals(s.Args(), "-drive")
+	devices := argVals(s.Args(), "-device")
+	for i, f := range files {
+		id := fmt.Sprintf("DataDisk%d", i)
+		// -drive: id/if=none pairing, the file, and the same perf tuning as MacHDD
+		if !slices.ContainsFunc(drives, func(d string) bool {
+			return strings.Contains(d, "id="+id) && strings.Contains(d, "if=none") &&
+				strings.Contains(d, "format=qcow2") && strings.Contains(d, "cache=writeback") &&
+				strings.Contains(d, "aio=io_uring") && strings.Contains(d, "discard=unmap") &&
+				strings.Contains(d, "detect-zeroes=unmap") && strings.Contains(d, "file="+f)
+		}) {
+			t.Errorf("data disk %d drive missing/mistuned: %v", i, drives)
+		}
+		// -device: ide-hd on the expected free SATA port, bound to the matching drive id
+		want := fmt.Sprintf("ide-hd,bus=sata.%d,drive=%s", wantPorts[i], id)
+		if !slices.Contains(devices, want) {
+			t.Errorf("data disk %d device: want %q in %v", i, want, devices)
+		}
+	}
+	// no data disks => no DataDisk drives at all
+	s.DataDisks = nil
+	if slices.ContainsFunc(argVals(s.Args(), "-drive"), func(d string) bool { return strings.Contains(d, "DataDisk") }) {
+		t.Errorf("no data disks must not emit DataDisk drives")
 	}
 }
 


### PR DESCRIPTION
## What

Adds data disks to `vm run`/`create`/`clone` through a repeatable `--data-disk` flag whose UX mirrors cocoon's: comma-separated `key=value` specs parsed into cocoon's `types.DataDiskSpec` (reused, not re-invented), validated with `types.ValidDataDiskName`.

```
cocoon-macos vm run <IMAGE> --data-disk size=20G --data-disk name=scratch,size=50G
```

- `size=` required, `units.RAMInBytes` syntax, min 16MiB (local const mirroring cocoon `hypervisor.MinDataDiskSize` — that package pulls in storage/metering/backend, so it is not import-worthy for one const).
- `name=` optional, defaults `data0`, `data1`, … ; duplicates error.
- Disks are created as empty qcow2 (`qemu-img create -f qcow2 <path> <bytes>`), attached with the **same AHCI/IDE perf tuning as MacHDD** (`cache=writeback,aio=io_uring,discard=unmap,detect-zeroes=unmap`), and roll back with the VM (snapshot/restore) and travel with `clone` (SRC's disks are reflink-copied; extra `--data-disk` specs add more, name collisions with a copied disk error).

## Intentional macOS divergences from cocoon

- **`fstype=` / `mount=` / `directio=` are rejected.** A macOS guest has no cloud-init/agent to partition, format, or mount a disk, so the disk is attached raw — the user formats it in-guest with Disk Utility / `diskutil`. cocoon's Linux path formats/mounts for you; here that would silently do nothing.
- **At most 4 data disks.** macOS has no virtio-blk driver (the OS disk itself rides AHCI), so data disks take the single `ich9-ahci` controller's remaining SATA ports. `OpenCoreBoot` (sata.2) and `MacHDD` (sata.4) leave exactly ports **0, 1, 3, 5** free. Enforced at parse time.

## Validation

- `gofumpt -l .` clean; `go build` + `GOOS=linux go build`; `golangci-lint` 0 issues for darwin **and** linux; `go test -race` green.
- New table-driven parser test (`cmd/vm/datadisk_test.go`): single/multi, default names, size units, missing/too-small size, bad/dup names, rejected `fstype`/`mount`/`directio`, >4 cap, clone-reserved collisions + cap.
- `qemu/launch_test.go` `TestArgsDataDisks`: port mapping `[0,1,3,5]`, `id`/`if=none` pairing, MacHDD-equal tuning, and no drives when empty.
- Drove the built binary: `--data-disk` shows in `--help`; below-min, `fstype=`, and >4 specs all error with clear messages; confirmed `qemu-img create <path> <bytes>` yields the expected qcow2.

## Stacking

Stacked on **PR 1** (`fix/audit-findings`); this PR targets that branch as its base. Review/merge PR 1 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)