### PR TITLE
ci: fix OCR click coordinates to match the forced GOP resolution

### DIFF
--- a/scripts/build-qemu-macos.sh
+++ b/scripts/build-qemu-macos.sh
@@ -43,6 +43,13 @@ QMP_SOCK="$WORKDIR/qmp.sock"
 QMP_PY="$ROOT_DIR/scripts/qmp-input.py"
 BOOT_SCREENSHOT_MINS=${BOOT_SCREENSHOT_MINS:-6}
 
+# Framebuffer geometry — single source: configure_opencore forces this GOP mode and qmp-input.py's
+# click mapping reads it via QMP_W/QMP_H. The two MUST match or every OCR-driven click scales
+# off-target by the ratio. 1920x1080 is a standard OVMF GOP mode.
+GOP_W=${GOP_W:-1920}
+GOP_H=${GOP_H:-1080}
+export QMP_W="$GOP_W" QMP_H="$GOP_H"
+
 GHCR_REPO=${GHCR_REPO:-"ghcr.io/cocoonstack/cocoon-macos/tahoe"}
 GHCR_TAG=${GHCR_TAG:-"26"}
 
@@ -138,7 +145,7 @@ configure_opencore() {  # patch OpenCore config.plist; arg "hide" => HideAuxilia
   local hide="${1:-}"
   local oc="$OPENCORE_QCOW2"
   [[ -f "$oc" ]] || { log "OpenCore.qcow2 missing; skip OC patch"; return 0; }
-  log "patching OpenCore config.plist: RequestBootVarRouting + 1920x1080 + Timeout (qemu-nbd)"
+  log "patching OpenCore config.plist: RequestBootVarRouting + ${GOP_W}x${GOP_H} + Timeout (qemu-nbd)"
   sudo modprobe nbd max_part=8 2>/dev/null || { log "no nbd module; skip OC patch"; return 0; }
   sudo qemu-nbd --connect=/dev/nbd0 -f qcow2 "$oc" 2>/dev/null || { log "qemu-nbd connect failed; skip"; return 0; }
   sleep 3
@@ -152,16 +159,15 @@ configure_opencore() {  # patch OpenCore config.plist; arg "hide" => HideAuxilia
     local cfg
     cfg=$(sudo find /mnt/oc -iname config.plist 2>/dev/null | head -1)
     if [[ -n "$cfg" ]]; then
-      # Force UEFI>Output>Resolution=1920x1080. Production reuses OSX-KVM's OVMF_VARS-1920x1080.fd,
-      # which pre-bakes that GOP mode; apt's stock OVMF_VARS_4M.fd boots at the default resolution, so
-      # the OCR click-through coordinates (fixed pixel positions) would land on the wrong controls.
-      # Setting it in config.plist reproduces the 1920x1080 framebuffer the OCR machinery expects.
-      sudo HIDE="$hide" python3 - "$cfg" <<'PY' || true
+      # Force the GOP mode that qmp-input.py's click mapping (QMP_W/QMP_H) assumes. Stock apt
+      # OVMF_VARS_4M.fd otherwise boots at OVMF's default resolution, and every OCR-driven click
+      # would then scale off-target against the real framebuffer.
+      sudo HIDE="$hide" RES="${GOP_W}x${GOP_H}" python3 - "$cfg" <<'PY' || true
 import plistlib, os, sys
 p = sys.argv[1]
 d = plistlib.load(open(p, "rb"))
 d.setdefault("Booter", {}).setdefault("Quirks", {})["RequestBootVarRouting"] = True
-d.setdefault("UEFI", {}).setdefault("Output", {})["Resolution"] = "1920x1080"
+d.setdefault("UEFI", {}).setdefault("Output", {})["Resolution"] = os.environ["RES"]
 b = d.setdefault("Misc", {}).setdefault("Boot", {})
 if os.environ.get("HIDE") == "hide":
     b["HideAuxiliary"] = True   # hide EFI/recovery -> only the installed macOS remains

--- a/scripts/qmp-input.py
+++ b/scripts/qmp-input.py
@@ -10,7 +10,7 @@ Usage:
   qmp-input.py SOCK move    PX PY      # move pointer only
   qmp-input.py SOCK key     K [K...]   # send qcode key(s), e.g. ret down spc
   qmp-input.py SOCK screendump FILE    # write framebuffer ppm
-Screen size defaults to 1280x800; override with QMP_W / QMP_H env vars.
+Screen size defaults to 1920x1080; override with QMP_W / QMP_H env vars.
 """
 import json
 import os
@@ -19,8 +19,8 @@ import subprocess
 import sys
 import time
 
-W = int(os.environ.get("QMP_W", "1280"))
-H = int(os.environ.get("QMP_H", "800"))
+W = int(os.environ.get("QMP_W", "1920"))
+H = int(os.environ.get("QMP_H", "1080"))
 
 CHARMAP = {
     " ": "spc", "\n": "ret", "\t": "tab", "-": "minus", "=": "equal",


### PR DESCRIPTION
## Root cause
tahoe `stage=install` (run 28567792539) hung at the Recovery chooser and failed after 40 OCR rounds. PR #4 forced `UEFI>Output>Resolution=1920x1080`, and this time it **actually took effect** (screenshots are 1920×1080), but `scripts/qmp-input.py` still hardcoded a **1280×800** canvas for its absolute-pointer mapping. So OCR found "Continue" at real pixel (1140,596) but `click()` scaled it against 1280×800 → the guest re-expanded it against the real 1920×1080 → cursor landed at ~(1710,805), missing every button.

Historically (pre-#4) the OSX-KVM path rendered at **1280×800** despite the `OVMF_VARS-1920x1080.fd` filename — coincidentally matching qmp-input.py's default, which is why clicks always worked and #4's rationale ("pre-bakes 1920×1080") was mistaken.

## Fix
Single source of truth: `GOP_W`/`GOP_H` in `build-qemu-macos.sh` — `configure_opencore` forces that GOP mode in the plist **and** `QMP_W`/`QMP_H` are exported from it, so the click mapping can't drift from the framebuffer again. `qmp-input.py` defaults updated to 1920×1080 for standalone use.

## Validation
- `bash -n` + `py_compile` clean; shellcheck no new findings.
- Click-math check: (1140,596) at 1920×1080 now re-expands to exactly (1140,596) — on target (was (1710,805)).
- Full pipeline re-run (`stage=install`) triggered after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)