### PR TITLE
ci: fix SLA-sheet click coords for 1920x1080; drop dead open_disk_utility

### DIFF
--- a/scripts/build-qemu-macos.sh
+++ b/scripts/build-qemu-macos.sh
@@ -99,11 +99,13 @@ agreebtn() {  # click the active SLA "Agree" button (Disagree-paired, topmost) �
   python3 "$QMP_PY" "$QMP_SOCK" agreebtn 2>&1 | sed 's/^/[agree] /' || true
 }
 
-modalagree() {  # the SLA confirm-sheet "Agree" is grey-on-grey and OCR-unreadable. The sheet is screen-centered,
-  # so click the Agree column (right of center, never Disagree) across the y where the button lands across
-  # versions (Tahoe ~399, Sequoia ~452 — body wraps push it down). One hits; the rest miss harmlessly.
-  local y
-  for y in 400 426 452; do click 688 "$y"; sleep 1; done
+modalagree() {  # the SLA confirm-sheet "Agree" is grey-on-grey and OCR-unreadable, so click by position.
+  # Measured at the forced 1920x1080 GOP: Tahoe's Agree center is (1018,526). The install window is
+  # horizontally screen-centered (x=GOP_W/2+58) but sits high, so y can't derive from GOP_H — bracket
+  # it downward to also catch Sequoia, whose longer body text wraps the button lower. Clicks stay in
+  # the Agree column (never Disagree at ~899) and the modal sheet absorbs any miss.
+  local x=$((GOP_W / 2 + 58)) y
+  for y in 520 546 572 598; do click "$x" "$y"; sleep 1; done
 }
 
 screendump() {  # screendump <label> — via QMP, not HMP: the monitor `screendump` emits empty (6-byte)
@@ -242,12 +244,6 @@ boot_to_recovery() {  # OpenCore picker -> macOS Base System -> Recovery window
   screendump "inst-01-recovery"
 }
 
-open_disk_utility() {  # Recovery chooser -> Disk Utility -> Continue
-  log "opening Disk Utility (click row + Continue)"
-  click 600 465; sleep 1; click 815 525
-  sleep 35
-  screendump "du-00-open"
-}
 
 erase_target() {  # open Terminal (Shift-Cmd-T), erase disk0 as APFS "Macintosh"
   log "erasing disk0 via Terminal"


### PR DESCRIPTION
## Root cause
`stage=install` (run 28572221552) hung 41 rounds at the license agreement. The OCR-coordinate fix (#7) corrected OCR-derived clicks, but `modalagree()` — which dismisses the grey-on-grey, OCR-unreadable SLA **confirm sheet** by position — still used raw **1280×800** literals (`click 688 400/426/452`). Against the forced 1920×1080 framebuffer those land at pixel (688,4xx), ~338px from the real button, on the license body text.

## Fix (screenshot-measured)
Forensics on the run's artifacts measured Tahoe's confirm-sheet Agree button at **center (1018,526)**, bbox y=[512,539]. Neither center-relative nor linear-scaled formulas fit reliably because the install window is **horizontally** screen-centered but sits **high** (vertical center ≈451, not 540). So:
- x = `GOP_W/2 + 58` (window is horizontally centered → robust to width).
- y bracketed downward `520 546 572 598` — covers Tahoe (measured 526) and Sequoia (longer SLA body wraps the button lower, same variance the old 400→452 bracket handled). Clicks stay in the Agree column (Disagree is at x≈899); the modal sheet absorbs misses.

Also **deletes `open_disk_utility`** — confirmed dead code (no call site; erase runs through `erase_target`'s keyboard `diskutil` path), carrying the same stale 1280×800 literals. After this, `grep 'click [0-9]'` finds zero literal-coordinate clicks; every other click is OCR-driven and resolution-agnostic.

## Validation
- `bash -n` clean; shellcheck no new findings; Go build sanity (no .go touched).
- Re-run of `stage=install` triggered after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)