### PR TITLE
ci: retry oras pull for transient ghcr PROTOCOL_ERROR on large base blobs

### DIFF
--- a/scripts/build-qemu-macos.sh
+++ b/scripts/build-qemu-macos.sh
@@ -331,8 +331,15 @@ capture_and_push() {  # stop QEMU, compress the installed macOS qcow2, push it t
 pull_image() {  # oras pull $GHCR_REPO:$1 -> $QCOW2_NAME (the boot disk; skips the ~50min install)
   cd "$OSX_KVM_DIR"
   log "pulling image $GHCR_REPO:$1"
-  oras pull "$GHCR_REPO:$1" -o .
-  [[ -f "$QCOW2_NAME" ]] || { log "FATAL: image $QCOW2_NAME not pulled from :$1"; exit 1; }
+  # retry: ghcr streams multi-GB base blobs over HTTP/2 and intermittently drops them with
+  # PROTOCOL_ERROR/stream errors, which is transient — a fresh pull almost always succeeds.
+  local attempt
+  for attempt in 1 2 3; do
+    oras pull "$GHCR_REPO:$1" -o . && break
+    log "oras pull attempt $attempt failed; retrying in $((attempt * 10))s"
+    sleep $((attempt * 10))
+  done
+  [[ -f "$QCOW2_NAME" ]] || { log "FATAL: image $QCOW2_NAME not pulled from :$1 after 3 attempts"; exit 1; }
   log "image present: $(du -h "$QCOW2_NAME" | cut -f1)"
 }
 


### PR DESCRIPTION
## Why
tahoe `stage=setup` (run 28579171001) failed at the very first step pulling the 35G `tahoe:26-base`:
```
Error: failed to copy content to .../macos-tahoe-26.qcow2: copy failed: stream error: stream ID 1; PROTOCOL_ERROR; received from peer
```
This is a transient HTTP/2 stream drop — ghcr intermittently resets the connection while streaming multi-GB base blobs. Not a logic bug; a fresh pull succeeds. It will recur across every stage that pulls a base (setup + verify, both versions), so harden the shared `pull_image`.

## Fix
Wrap `pull_image`'s `oras pull` in a 3-attempt retry with linear backoff (10s, 20s). No behavior change on success.

## Validation
`bash -n` clean, shellcheck no new findings. (No Go touched.) Re-run of tahoe setup on the hardened pipeline follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)