### PR TITLE
ci: keyboard-ret backup on the installer intro pane (fixes Sequoia install hang)

### DIFF
--- a/scripts/build-qemu-macos.sh
+++ b/scripts/build-qemu-macos.sh
@@ -276,7 +276,10 @@ drive_installer() {  # adaptive: OCR the current installer pane each round, clic
     elif printf '%s' "$txt" | grep -qiE "Loading Installation"; then
       log "round $round: still loading installation information, waiting"; sleep 12
     elif printf '%s' "$txt" | grep -qiE "set up the installation|click Continue"; then
-      log "round $round: intro -> Continue"; ocrclick Continue; sleep 6
+      # keys ret backs up the OCR click: the intro Continue is the sole blue/default button, and its
+      # label OCRs at borderline confidence (~16 on Sequoia, ~45 on Tahoe) that can fall under the
+      # conf>=30 cutoff. A stray ret after the pane advances is a no-op (the SLA pane has no default).
+      log "round $round: intro -> Continue (blue default, keys ret backup)"; ocrclick Continue; sleep 2; keys ret; sleep 4
     else
       log "round $round: unrecognized pane, waiting"; sleep 10
     fi


### PR DESCRIPTION
## Root cause (screenshot forensics)
Sequoia `stage=install` (run 28579183005) hung 41 rounds at the installer **intro** pane: `ocrclick Continue` returned `NOTFOUND` every round. The "Continue" button is clearly rendered and is the sole blue/default button, but tesseract reads its tiny label at **confidence 16**, below `qmp-input.py`'s hardcoded `conf>=30` cutoff, so `ocr_find` discards it. Tahoe's identical button reads at conf ~45 — above the line — which is why tahoe's install passed. **Both are marginal; tahoe just landed on the passing side.** The intro handler (unlike disk-select) had no keyboard backup.

## Fix
Mirror the disk-select handler: after `ocrclick Continue`, add `keys ret`. Continue is the pane's sole blue/default button, so Return activates it regardless of OCR confidence — making the intro robust for **both** versions.

## Risk (low)
If OCR already advanced the pane before `keys ret` fires, the stray Return is a no-op: the SLA pane renders Agree/Disagree as equal-weight grey pills with **no default button** (Apple deliberately prevents Enter-accept), and the interstitial spinner has no buttons — both verified from the tahoe screenshots. The `keys ret`-after-`ocrclick` idiom is already proven at disk-select.

## Validation
`bash -n` clean. Re-run of sequoia install on the fixed pipeline follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)