### PR TITLE
fix(image): retry oras-go pull on transient ghcr stream drops

### DIFF
--- a/cmd/image/handler.go
+++ b/cmd/image/handler.go
@@ -48,12 +48,30 @@ func (h *Handler) Pull(cmd *cobra.Command, args []string) error {
 	// blob straight into the store. Credentials still come from the user's docker config (public
 	// images pull anonymously), so no external oras binary is needed.
 	logger.Debugf(ctx, "pulling OCI artifact %s via oras-go", ref)
-	rc, err := pullOCILayer(ctx, ref)
-	if err != nil {
-		return err
+	// retry transient registry stream drops: ghcr resets the HTTP/2 stream on multi-GB blobs with
+	// PROTOCOL_ERROR mid-copy. A fresh fetch (from the start — mid-stream can't resume) usually wins.
+	var perr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		rc, ferr := pullOCILayer(ctx, ref)
+		if ferr != nil {
+			perr = ferr
+		} else {
+			perr = s.ImportFromReader(ctx, ref, progress.Nop, rc)
+			_ = rc.Close()
+		}
+		if perr == nil {
+			return nil
+		}
+		logger.Warnf(ctx, "oras pull attempt %d/3 failed: %v", attempt, perr)
+		if attempt < 3 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(attempt) * 10 * time.Second):
+			}
+		}
 	}
-	defer func() { _ = rc.Close() }()
-	return s.ImportFromReader(ctx, ref, progress.Nop, rc)
+	return fmt.Errorf("pull %s after 3 attempts: %w", ref, perr)
 }
 
 // List renders stored images as a table (NAME TYPE SIZE DIGEST CREATED), or JSON with -o json.


### PR DESCRIPTION
## Why
`cocoon-macos image pull <ghcr ref>` failed pulling the 35G `tahoe:26` with:
```
copy to temp: stream error: stream ID 1; PROTOCOL_ERROR; received from peer
```
ghcr intermittently resets the HTTP/2 stream on multi-GB blobs. The native oras-go path (#5) had **no retry** — the CI's `pull_image` got one in #10, but the shipped binary's pull didn't. So a single transient drop aborts the whole pull.

## Fix
Wrap the fetch+import in a 3-attempt retry with linear backoff (10s, 20s), ctx-cancellable. Mid-stream failures can't resume, so each attempt re-fetches from the start (cloudimg's temp uses last-writer-wins, so a partial temp from a failed attempt is safe to overwrite).

## Validation
gofumpt clean; build + golangci-lint (darwin & linux) 0 issues; `go test -race ./cmd/image/...` green. Re-pull of tahoe:26 on 79 with the rebuilt binary follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)