### PR TITLE
fix(image): parallel Range-fetch guards + splitRanges test

### DIFF
--- a/cmd/image/oci.go
+++ b/cmd/image/oci.go
@@ -100,20 +100,26 @@ func rangeSupported(ctx context.Context, client *auth.Client, url string) bool {
 
 // fetchParallel downloads [0,size) in pullConns chunks concurrently, each writing at its offset.
 func fetchParallel(ctx context.Context, client *auth.Client, url string, size int64, f *os.File) error {
-	chunk := (size + pullConns - 1) / pullConns
 	g, gctx := errgroup.WithContext(ctx)
-	for i := range int64(pullConns) {
-		start := i * chunk
-		if start >= size {
-			break
-		}
+	for _, r := range splitRanges(size, pullConns) {
+		start, end := r[0], r[1]
+		g.Go(func() error { return fetchRange(gctx, client, url, start, end, f) })
+	}
+	return g.Wait()
+}
+
+// splitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
+func splitRanges(size int64, n int) [][2]int64 {
+	chunk := (size + int64(n) - 1) / int64(n)
+	var ranges [][2]int64
+	for start := int64(0); start < size; start += chunk {
 		end := start + chunk - 1
 		if end >= size {
 			end = size - 1
 		}
-		g.Go(func() error { return fetchRange(gctx, client, url, start, end, f) })
+		ranges = append(ranges, [2]int64{start, end})
 	}
-	return g.Wait()
+	return ranges
 }
 
 func fetchRange(ctx context.Context, client *auth.Client, url string, start, end int64, f *os.File) error {
@@ -130,9 +136,20 @@ func fetchRange(ctx context.Context, client *auth.Client, url string, start, end
 	if resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("range %d-%d: unexpected status %s", start, end, resp.Status)
 	}
-	// each chunk owns a disjoint region, so concurrent WriteAt via the offset writer never overlaps
-	_, err = io.Copy(io.NewOffsetWriter(f, start), resp.Body)
-	return err
+	// A mismatched span lands bytes at the wrong offset; a short body leaves a zero
+	// hole — both would only surface after verifyDigest re-hashes the whole file.
+	if cr := resp.Header.Get("Content-Range"); !strings.HasPrefix(cr, fmt.Sprintf("bytes %d-%d/", start, end)) {
+		return fmt.Errorf("range %d-%d: mismatched content-range %q", start, end, cr)
+	}
+	want := end - start + 1
+	n, err := io.Copy(io.NewOffsetWriter(f, start), io.LimitReader(resp.Body, want))
+	if err != nil {
+		return err
+	}
+	if n != want {
+		return fmt.Errorf("range %d-%d: short body %d of %d bytes", start, end, n, want)
+	}
+	return nil
 }
 
 // fetchSingle streams the blob in one connection (fallback when Range isn't supported).

--- a/cmd/image/oci.go
+++ b/cmd/image/oci.go
@@ -17,6 +17,8 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 // pullConns is the number of parallel HTTP Range connections used to fetch a blob; ghcr throttles a
@@ -101,25 +103,11 @@ func rangeSupported(ctx context.Context, client *auth.Client, url string) bool {
 // fetchParallel downloads [0,size) in pullConns chunks concurrently, each writing at its offset.
 func fetchParallel(ctx context.Context, client *auth.Client, url string, size int64, f *os.File) error {
 	g, gctx := errgroup.WithContext(ctx)
-	for _, r := range splitRanges(size, pullConns) {
+	for _, r := range utils.SplitRanges(size, pullConns) {
 		start, end := r[0], r[1]
 		g.Go(func() error { return fetchRange(gctx, client, url, start, end, f) })
 	}
 	return g.Wait()
-}
-
-// splitRanges divides [0,size) into up to n contiguous, inclusive-ended byte ranges.
-func splitRanges(size int64, n int) [][2]int64 {
-	chunk := (size + int64(n) - 1) / int64(n)
-	var ranges [][2]int64
-	for start := int64(0); start < size; start += chunk {
-		end := start + chunk - 1
-		if end >= size {
-			end = size - 1
-		}
-		ranges = append(ranges, [2]int64{start, end})
-	}
-	return ranges
 }
 
 func fetchRange(ctx context.Context, client *auth.Client, url string, start, end int64, f *os.File) error {
@@ -133,23 +121,7 @@ func fetchRange(ctx context.Context, client *auth.Client, url string, start, end
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusPartialContent {
-		return fmt.Errorf("range %d-%d: unexpected status %s", start, end, resp.Status)
-	}
-	// A mismatched span lands bytes at the wrong offset; a short body leaves a zero
-	// hole — both would only surface after verifyDigest re-hashes the whole file.
-	if cr := resp.Header.Get("Content-Range"); !strings.HasPrefix(cr, fmt.Sprintf("bytes %d-%d/", start, end)) {
-		return fmt.Errorf("range %d-%d: mismatched content-range %q", start, end, cr)
-	}
-	want := end - start + 1
-	n, err := io.Copy(io.NewOffsetWriter(f, start), io.LimitReader(resp.Body, want))
-	if err != nil {
-		return err
-	}
-	if n != want {
-		return fmt.Errorf("range %d-%d: short body %d of %d bytes", start, end, n, want)
-	}
-	return nil
+	return utils.CopyRangeBody(resp, io.NewOffsetWriter(f, start), start, end)
 }
 
 // fetchSingle streams the blob in one connection (fallback when Range isn't supported).

--- a/cmd/image/oci_test.go
+++ b/cmd/image/oci_test.go
@@ -69,31 +69,3 @@ func TestPickQcow2Layer(t *testing.T) {
 		})
 	}
 }
-
-func TestSplitRanges(t *testing.T) {
-	sizes := []int64{1, 7, 8, 9, 100, 257 << 10, (257 << 10) + 7}
-	for _, size := range sizes {
-		for _, n := range []int{1, 3, 8, 100} {
-			ranges := splitRanges(size, n)
-			if len(ranges) == 0 {
-				t.Fatalf("size=%d n=%d: no ranges", size, n)
-			}
-			if ranges[0][0] != 0 {
-				t.Errorf("size=%d n=%d: first start %d, want 0", size, n, ranges[0][0])
-			}
-			if last := ranges[len(ranges)-1][1]; last != size-1 {
-				t.Errorf("size=%d n=%d: last end %d, want %d", size, n, last, size-1)
-			}
-			// contiguous + non-overlapping: each start is the previous end + 1
-			for i := 1; i < len(ranges); i++ {
-				if ranges[i][0] != ranges[i-1][1]+1 {
-					t.Errorf("size=%d n=%d: gap/overlap at %d: %v after %v", size, n, i, ranges[i], ranges[i-1])
-				}
-			}
-			// every range is non-empty and never exceeds n chunks
-			if len(ranges) > n {
-				t.Errorf("size=%d n=%d: %d chunks exceeds n", size, n, len(ranges))
-			}
-		}
-	}
-}

--- a/cmd/image/oci_test.go
+++ b/cmd/image/oci_test.go
@@ -69,3 +69,31 @@ func TestPickQcow2Layer(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitRanges(t *testing.T) {
+	sizes := []int64{1, 7, 8, 9, 100, 257 << 10, (257 << 10) + 7}
+	for _, size := range sizes {
+		for _, n := range []int{1, 3, 8, 100} {
+			ranges := splitRanges(size, n)
+			if len(ranges) == 0 {
+				t.Fatalf("size=%d n=%d: no ranges", size, n)
+			}
+			if ranges[0][0] != 0 {
+				t.Errorf("size=%d n=%d: first start %d, want 0", size, n, ranges[0][0])
+			}
+			if last := ranges[len(ranges)-1][1]; last != size-1 {
+				t.Errorf("size=%d n=%d: last end %d, want %d", size, n, last, size-1)
+			}
+			// contiguous + non-overlapping: each start is the previous end + 1
+			for i := 1; i < len(ranges); i++ {
+				if ranges[i][0] != ranges[i-1][1]+1 {
+					t.Errorf("size=%d n=%d: gap/overlap at %d: %v after %v", size, n, i, ranges[i], ranges[i-1])
+				}
+			}
+			// every range is non-empty and never exceeds n chunks
+			if len(ranges) > n {
+				t.Errorf("size=%d n=%d: %d chunks exceeds n", size, n, len(ranges))
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon-macos
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5
+	github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105
 	github.com/docker/go-units v0.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon-macos
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon v0.4.5
+	github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5
 	github.com/docker/go-units v0.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon v0.4.5 h1:FoLgZhXdfKFvTJcF1ijb6A3C4n22NDOtwT2FDsoJbgM=
-github.com/cocoonstack/cocoon v0.4.5/go.mod h1:LOFTBWiRXYsZJtNIF6UctDO0gThKCaG5+NOQ+ahGgv8=
+github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5 h1:ZcxPePItTkp1mnpehnLQdmTX4zq+wRYrC+rqLNEHq/U=
+github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5/go.mod h1:Rl/SAzj1RbyL8XJaIyWiHdT96yK2D1e0xCr8flVqIcA=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.0 h1:Mg3SXBdRGkdXyFC4lcwr6u2ZB2SDeL6LC3U+QrEANuQ=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5 h1:ZcxPePItTkp1mnpehnLQdmTX4zq+wRYrC+rqLNEHq/U=
-github.com/cocoonstack/cocoon v0.4.6-0.20260704023024-7e4406fbe5f5/go.mod h1:Rl/SAzj1RbyL8XJaIyWiHdT96yK2D1e0xCr8flVqIcA=
+github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105 h1:kY2QEEK+RiJflgTGRfvRZJvN4X87d36dkrneyOZiAMI=
+github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105/go.mod h1:Rl/SAzj1RbyL8XJaIyWiHdT96yK2D1e0xCr8flVqIcA=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.0 h1:Mg3SXBdRGkdXyFC4lcwr6u2ZB2SDeL6LC3U+QrEANuQ=

--- a/home/home.go
+++ b/home/home.go
@@ -43,7 +43,7 @@ func VMDir(cmd *cobra.Command, name string) string {
 // command context alongside it.
 func OpenStore(cmd *cobra.Command) (context.Context, *cloudimg.CloudImg, error) {
 	ctx := cliutil.CommandContext(cmd)
-	s, err := cloudimg.New(ctx, Dir(cmd))
+	s, err := cloudimg.New(ctx, Dir(cmd), 0) // 0 = cloudimg's default pull connections
 	if err != nil {
 		return ctx, nil, fmt.Errorf("init cloudimg store: %w", err)
 	}


### PR DESCRIPTION
Adversarial-review finding on tonight's parallel OCI blob pull (mirrors the cocoon parallel-download guards).

## Fix
- **fetchRange** validated only status 206, then `io.Copy`'d the body at the chunk offset with no length or range check. A misbehaving CDN edge (short 206 body, or a 206 whose actual range differs from the request) would land bytes at the wrong offset / leave a zero hole. It's backstopped by `verifyDigest` (digest mismatch), but only after re-hashing the whole multi-GB file **three times** — an opaque, expensive failure. Add the **Content-Range prefix check** and the **n==want short-body guard** so a bad range fails fast and precisely.
- **splitRanges** extracted from `fetchParallel` and unit-tested (contiguous, non-overlapping, covers [0,size), ≤n chunks) so the disjoint-offset invariant that makes concurrent pwrite safe can't silently regress.

(pullConns is a const 8 here, so the unbounded-conn footgun flagged in cocoon does not apply.)

## Verification
GOWORK=off build/test/`-race` green; lint 0 issues both GOOS; fmt-check clean.