### PR TITLE
perf(image): disable XProtect scan launchds in firstboot

### DIFF
--- a/scripts/provision-macos.sh
+++ b/scripts/provision-macos.sh
@@ -181,6 +181,12 @@ for i in 1 2 3 4 5; do /usr/bin/mdutil -a -i off >/dev/null 2>&1 && break; sleep
 for svc in com.apple.photoanalysisd com.apple.mediaanalysisd com.apple.parsecd com.apple.suggestd; do
   /bin/launchctl disable "user/501/$svc" 2>/dev/null || true
 done
+# XProtect malware scans (startup + periodic) burn ~75% CPU for ~2min on every boot (measured on a
+# 2-vCPU tahoe:26 VM); a disposable headless VM needs no on-access scanning, so disable the scan
+# launchds. system domain, so the persisted disable-override survives this daemon self-removing.
+for svc in com.apple.XProtect.daemon.scan.startup com.apple.XProtect.daemon.scan; do
+  /bin/launchctl disable "system/$svc" 2>/dev/null || true
+done
 echo "spotlight: $(/usr/bin/mdutil -a -s 2>/dev/null | tr '\n' ' ')"
 /bin/rm -f /Library/LaunchDaemons/com.cocoon.firstboot.plist /usr/local/bin/cocoon-firstboot.sh
 SH


### PR DESCRIPTION
## What

Add the two XProtect malware-scan launchds to the set the first-boot daemon disables (alongside the existing Spotlight + analysis-daemon trims):

- `com.apple.XProtect.daemon.scan.startup`
- `com.apple.XProtect.daemon.scan`

Disabled in the `system` domain so the persisted disable-override survives the first-boot daemon self-removing.

## Why

On a fresh boot, `XProtectRemediator` runs a startup + periodic malware scan that burns ~75% of a CPU core for ~2 minutes. Measured on a `tahoe:26` 2-vCPU VM (host qemu-process CPU, settle curve):

| ~time after boot | host qemu CPU | top guest process |
|---|---|---|
| 0–60s | ~120% | `iconservicesagent` (icon-cache rebuild) |
| 90–180s | ~12% | (settled) |
| 200–300s | ~75–115% | **`XProtectRemediator` + `system_installd`** |
| 315s+ | ~7–13% | steady idle |

Steady idle is already low (~3–4% of a core); the "idle VM burns cores" symptom is these two transient first-boot storms. A disposable, headless VM running known workloads does not need on-access malware scanning, so disabling the scan removes the second storm on every boot.

## Trade-off

Reduces the guest's built-in malware scanning. This is consistent with the first-boot daemon already disabling Spotlight indexing and the analysis daemons for the same headless/disposable use case, but it is a security-posture change — flagging it explicitly for review.

## Scope / testing

- Mechanism validated live on a running `tahoe:26` guest: after `launchctl disable system/com.apple.XProtect.daemon.scan{,.startup}`, `launchctl print-disabled system` reports both `=> disabled`.
- Takes effect on the next golden-image rebuild (the daemon runs at first boot).
- Out of scope (separate follow-up): the first storm, `iconservicesagent`, is caused by `slim_disk()` deleting `/Library/Caches/*`; preserving the icon cache trades image size for first-boot CPU and needs a full image rebuild to validate.
