### PR TITLE
sync: pull cocoon v0.5.1 updates (idle-TAP softirq fix + dep bump)

### DIFF
--- a/cmd/vm/datadisk.go
+++ b/cmd/vm/datadisk.go
@@ -133,7 +133,7 @@ func copyDataDisks(dir string, src []string) ([]string, error) {
 	paths := make([]string, 0, len(src))
 	for _, srcPath := range src {
 		dst := filepath.Join(dir, filepath.Base(srcPath))
-		if err := utils.ReflinkCopy(dst, srcPath); err != nil {
+		if err := utils.ReflinkCopy(dst, srcPath, utils.Sync); err != nil {
 			return nil, fmt.Errorf("copy data disk %s: %w", filepath.Base(srcPath), err)
 		}
 		paths = append(paths, dst)

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -64,6 +64,7 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err := h.launch(cmd, dir, r); err != nil {
 				return err
 			}
+			unquiesceNet(cmd, r)
 			fmt.Printf("%s (pid %d)\n", n, r.PID)
 			return nil
 		}); err != nil {
@@ -85,6 +86,7 @@ func (h *Handler) Stop(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			terminate(ctx, r, grace)
+			quiesceNet(cmd, r)
 			stopVNCProxy(ctx, dir)
 			r.PID, r.VNCDisp, r.VNCPass = 0, -1, "" // VNC is launch-scoped: gone with the qemu it belonged to
 			return saveRec(dir, r)

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/projecteru2/core/log"
 	"github.com/spf13/cobra"
+	"github.com/vishvananda/netlink"
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
@@ -84,9 +85,8 @@ func teardownNet(cmd *cobra.Command, r *record) {
 	if provider, err := newProvider(cmd, r); err != nil {
 		logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
 	} else {
-		// quiesce before Delete: a killed VMM leaves the TAP carrier-less while its veth stays up on
-		// the bridge, so tc mirred redirect storms host softirqs against the down device in the window
-		// before Delete removes the redirect (long enough to soft-lock a host on a busy bridge).
+		// quiesce before Delete closes the same idle-TAP softirq window quiesceNet guards, for the gap
+		// between the VMM dying and Delete dropping the redirect.
 		if err := provider.Quiesce(ctx, r.VMID); err != nil {
 			logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
 		}
@@ -101,10 +101,9 @@ func teardownNet(cmd *cobra.Command, r *record) {
 	}
 }
 
-// quiesceNet brings a stopped VM's auto-created host NICs down so the carrier-less TAP a dead VMM
-// leaves behind can't storm host softirqs (CNI: tc mirred redirect firing against the down device
-// per broadcast packet). unquiesceNet reverses it on restart. Best-effort, gated on ownership like
-// teardownNet — never touches a user-supplied --tap.
+// quiesceNet brings a stopped VM's owned host NICs down so a dead VMM's carrier-less TAP can't storm
+// host softirqs (tc mirred redirect firing against the down device per broadcast packet) — CNI via
+// the provider's veths, tap/bridge via setTapLink. unquiesceNet reverses it on start.
 func quiesceNet(cmd *cobra.Command, r *record) {
 	if !r.TapOwned {
 		return
@@ -116,7 +115,7 @@ func quiesceNet(cmd *cobra.Command, r *record) {
 	} else if err := provider.Quiesce(ctx, r.VMID); err != nil {
 		logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
 	}
-	setTapLink(ctx, r, "down")
+	setTapLink(ctx, r, false)
 }
 
 func unquiesceNet(cmd *cobra.Command, r *record) {
@@ -130,19 +129,28 @@ func unquiesceNet(cmd *cobra.Command, r *record) {
 	} else if err := provider.Unquiesce(ctx, r.VMID); err != nil {
 		logger.Warnf(ctx, "unquiesce network for %s: %v", r.VMID, err)
 	}
-	setTapLink(ctx, r, "up")
+	setTapLink(ctx, r, true)
 }
 
-// setTapLink toggles the host TAP's admin state for --net tap|bridge, where cocoon's bridge backend
-// no-ops Quiesce and QEMU opens the TAP with script=no (never touching its link): on stop the
-// readerless TAP would otherwise sit up on the bridge, and on restart stay down until raised. CNI's
-// TAP lives in a netns and is handled by the provider, so this is scoped to the host-side modes.
-func setTapLink(ctx context.Context, r *record, state string) {
-	if r.Tap == "" || (r.NetMode != netTAP && r.NetMode != netBridge) {
+// setTapLink flips a host TAP's admin state (down on stop, up on start). QEMU opens it with script=no
+// and cocoon's bridge backend no-ops Quiesce, so cocoon-macos owns the toggle; a CNI TAP lives in a
+// netns (r.Netns != "") and is the provider's job, so this only reaches host-netns TAPs.
+func setTapLink(ctx context.Context, r *record, up bool) {
+	if r.Tap == "" || r.Netns != "" {
 		return
 	}
-	if err := exec.CommandContext(ctx, "ip", "link", "set", r.Tap, state).Run(); err != nil {
-		log.WithFunc("cmd.vm.setTapLink").Warnf(ctx, "set tap %s %s: %v", r.Tap, state, err)
+	logger := log.WithFunc("cmd.vm.setTapLink")
+	link, err := netlink.LinkByName(r.Tap)
+	if err != nil {
+		logger.Warnf(ctx, "find tap %s: %v", r.Tap, err)
+		return
+	}
+	set := netlink.LinkSetUp
+	if !up {
+		set = netlink.LinkSetDown
+	}
+	if err := set(link); err != nil {
+		logger.Warnf(ctx, "set tap %s up=%v: %v", r.Tap, up, err)
 	}
 }
 

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -83,13 +83,66 @@ func teardownNet(cmd *cobra.Command, r *record) {
 	// warn instead of failing: rm must proceed, but a leaked TAP/netns should leave a trail
 	if provider, err := newProvider(cmd, r); err != nil {
 		logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
-	} else if _, err := provider.Delete(ctx, []string{r.VMID}); err != nil {
-		logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
+	} else {
+		// quiesce before Delete: a killed VMM leaves the TAP carrier-less while its veth stays up on
+		// the bridge, so tc mirred redirect storms host softirqs against the down device in the window
+		// before Delete removes the redirect (long enough to soft-lock a host on a busy bridge).
+		if err := provider.Quiesce(ctx, r.VMID); err != nil {
+			logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
+		}
+		if _, err := provider.Delete(ctx, []string{r.VMID}); err != nil {
+			logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
+		}
 	}
 	// CleanupTAPs runs unconditionally: it removes bt<vmid>-* by name and must not be gated on
 	// newProvider succeeding (rm has no --bridge flag), or an auto-created TAP would leak.
 	if r.NetMode == netTAP || r.NetMode == netBridge {
 		bridge.CleanupTAPs([]string{r.VMID})
+	}
+}
+
+// quiesceNet brings a stopped VM's auto-created host NICs down so the carrier-less TAP a dead VMM
+// leaves behind can't storm host softirqs (CNI: tc mirred redirect firing against the down device
+// per broadcast packet). unquiesceNet reverses it on restart. Best-effort, gated on ownership like
+// teardownNet — never touches a user-supplied --tap.
+func quiesceNet(cmd *cobra.Command, r *record) {
+	if !r.TapOwned {
+		return
+	}
+	ctx := cliutil.CommandContext(cmd)
+	logger := log.WithFunc("cmd.vm.quiesceNet")
+	if provider, err := newProvider(cmd, r); err != nil {
+		logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
+	} else if err := provider.Quiesce(ctx, r.VMID); err != nil {
+		logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
+	}
+	setTapLink(ctx, r, "down")
+}
+
+func unquiesceNet(cmd *cobra.Command, r *record) {
+	if !r.TapOwned {
+		return
+	}
+	ctx := cliutil.CommandContext(cmd)
+	logger := log.WithFunc("cmd.vm.unquiesceNet")
+	if provider, err := newProvider(cmd, r); err != nil {
+		logger.Warnf(ctx, "unquiesce network for %s: %v", r.VMID, err)
+	} else if err := provider.Unquiesce(ctx, r.VMID); err != nil {
+		logger.Warnf(ctx, "unquiesce network for %s: %v", r.VMID, err)
+	}
+	setTapLink(ctx, r, "up")
+}
+
+// setTapLink toggles the host TAP's admin state for --net tap|bridge, where cocoon's bridge backend
+// no-ops Quiesce and QEMU opens the TAP with script=no (never touching its link): on stop the
+// readerless TAP would otherwise sit up on the bridge, and on restart stay down until raised. CNI's
+// TAP lives in a netns and is handled by the provider, so this is scoped to the host-side modes.
+func setTapLink(ctx context.Context, r *record, state string) {
+	if r.Tap == "" || (r.NetMode != netTAP && r.NetMode != netBridge) {
+		return
+	}
+	if err := exec.CommandContext(ctx, "ip", "link", "set", r.Tap, state).Run(); err != nil {
+		log.WithFunc("cmd.vm.setTapLink").Warnf(ctx, "set tap %s %s: %v", r.Tap, state, err)
 	}
 }
 

--- a/cmd/vm/net_other.go
+++ b/cmd/vm/net_other.go
@@ -19,6 +19,10 @@ func provisionNet(_ *cobra.Command, _ *record) (tap, netns, mac string, err erro
 
 func teardownNet(_ *cobra.Command, _ *record) {}
 
+func quiesceNet(_ *cobra.Command, _ *record) {}
+
+func unquiesceNet(_ *cobra.Command, _ *record) {}
+
 // launchCmd builds the qemu exec; qemu-system-x86_64 is the authoritative VMM with no Go-native
 // equivalent (and off Linux there is no netns to enter).
 func launchCmd(_ *record, args []string) *exec.Cmd {

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -78,7 +78,7 @@ func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir,
 		return "", "", "", "", err
 	}
 	ovmfVars = filepath.Join(dir, varsName)
-	if err = utils.ReflinkCopy(ovmfVars, varsSrc); err != nil {
+	if err = utils.ReflinkCopy(ovmfVars, varsSrc, utils.Sync); err != nil {
 		return "", "", "", "", fmt.Errorf("copy OVMF_VARS: %w", err)
 	}
 	return dir, overlay, ovmfVars, digest, nil

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -1,0 +1,35 @@
+package vm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// TestGraceFromFlags pins the shared stop/rm force mapping: --force is an immediate SIGKILL
+// (grace 0), everything else waits the ACPI grace window.
+func TestGraceFromFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		force bool
+		want  time.Duration
+	}{
+		{name: "force is immediate", force: true, want: 0},
+		{name: "default waits the grace window", force: false, want: stopGracePeriod},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("force", false, "")
+			if tt.force {
+				if err := cmd.Flags().Set("force", "true"); err != nil {
+					t.Fatalf("set force: %v", err)
+				}
+			}
+			if got := graceFromFlags(cmd); got != tt.want {
+				t.Errorf("graceFromFlags(force=%v): got %v, want %v", tt.force, got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c
 	github.com/spf13/cobra v1.10.2
+	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/sync v0.21.0
 	howett.net/plist v1.0.1
 	oras.land/oras-go/v2 v2.6.1
@@ -36,7 +37,6 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/vishvananda/netlink v1.3.1 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.50.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon-macos
 go 1.26.4
 
 require (
-	github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105
+	github.com/cocoonstack/cocoon v0.5.2-0.20260713182614-0f6c21b5b6f6
 	github.com/docker/go-units v0.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105 h1:kY2QEEK+RiJflgTGRfvRZJvN4X87d36dkrneyOZiAMI=
-github.com/cocoonstack/cocoon v0.4.6-0.20260704025747-d9fa4dfb5105/go.mod h1:Rl/SAzj1RbyL8XJaIyWiHdT96yK2D1e0xCr8flVqIcA=
+github.com/cocoonstack/cocoon v0.5.2-0.20260713182614-0f6c21b5b6f6 h1:OKpbRm7j/WoON1iB26jiIshYwzLibu+5f/p49Um0rzc=
+github.com/cocoonstack/cocoon v0.5.2-0.20260713182614-0f6c21b5b6f6/go.mod h1:Rl/SAzj1RbyL8XJaIyWiHdT96yK2D1e0xCr8flVqIcA=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.0 h1:Mg3SXBdRGkdXyFC4lcwr6u2ZB2SDeL6LC3U+QrEANuQ=


### PR DESCRIPTION
Ports the applicable changes from cocoon (now v0.5.1) into cocoon-macos.

Closes #19.

## Included

**1. Bump cocoon v0.4.6 → v0.5.1** (`f308eb0`)
Picks up shared-package fixes cocoon-macos gets for free through its imports: flock poll 100ms→2ms (#114), store `Update` fsyncs off the flock hold (#126), `/proc`-scan tolerance for pids that vanish mid-scan (#129), per-NIC CNI teardown (#111). Adapts the two `utils.ReflinkCopy` call sites to its new `SyncMode` arg (`utils.Sync`, preserving the prior fsync).

**2. Quiesce host NICs on stop/rm — port of cocoon #130** (`00e2c3e`, `4a2f113`)
A stopped CNI VM keeps its netns/TAP for a fast restart, but the dead VMM leaves the TAP carrier-less while its veth stays up on the bridge; tc mirred redirect then fires against the down device per LAN broadcast, storming softirqs until the host soft-locks — a host-crash landmine for any stopped or `rm`'d CNI VM. Now `Quiesce` on stop and on rm (before `Delete`), `Unquiesce` on start.

cocoon's bridge backend no-ops `Quiesce` (bridge TAPs have no tc redirect), and QEMU opens the TAP with `script=no` and never touches its link, so `--net tap|bridge` toggles the host TAP directly via `netlink.LinkSetUp/Down` (host netns only — a CNI TAP is the provider's job). netlink was already an indirect dependency, promoted to direct.

**Start ordering note (vs #19's proposed scope).** #19 proposed unquiesce *before* launching QEMU and re-quiesce on launch failure. This PR unquiesces *after* a successful launch instead: unquiescing before QEMU opens the TAP would briefly recreate the exact carrier-less-TAP + veth-up condition the fix removes (a storm window on every start), whereas launching first means the TAP already has carrier when the veths come up, and a failed launch simply leaves the network quiesced (no rollback needed). Same end state (veths up iff the VM is running), without reopening the window.

**3. Guard test for the stop/rm force→grace mapping** (`e5bd110`)
Pins `--force` → immediate SIGKILL (grace 0), default → the ACPI grace window; mirrors cocoon f6ebebc.

## Assessed and skipped (already satisfied / not applicable)

- **symlink-proof volume checks (#101)** — N/A: cocoon-macos has no external-volume attach; `--data-disk` only creates fresh qcow2s under the VM dir, so there is no external path to symlink-smuggle a managed root through.
- **parallel Range download dedup** — already done: `cmd/image/oci.go` already builds on `utils.SplitRanges` / `utils.CopyRangeBody`.
- **List off-lock (#60)** — already done: `List` reads records via `ReadDir` + `loadRec` with no per-VM lock, and `saveRec` is atomic (`utils.AtomicWriteJSON`), so lock-free reads are safe.
- CH / Firecracker / android / vsock / hibernate / erofs-specific changes — not applicable to the qemu + macOS backend.

## Validation

`go build`, `go vet`, and `go test` are green on both `GOOS=linux` and `GOOS=darwin`. Reviewed with a reuse/simplification/efficiency/altitude pass; the netlink swap and the `r.Netns` gate on `setTapLink` came out of it.
