### PR TITLE
ci: bump pinned actions to current majors and go to 1.26.5

### DIFF
--- a/.github/workflows/build-macos-image.yml
+++ b/.github/workflows/build-macos-image.yml
@@ -36,7 +36,7 @@ jobs:
       STAGE: ${{ github.event.inputs.stage }}
       DISK_SIZE: ${{ github.event.inputs.disk_size }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Resolve macOS target (shortname + ghcr repo/tag + qcow2 name)
         run: |
@@ -73,7 +73,7 @@ jobs:
 
       - name: Log in to ghcr
         if: ${{ github.event.inputs.stage != 'boot' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload artifacts (screenshots / logs)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-build-${{ github.event.inputs.macos }}-${{ github.event.inputs.stage }}
           path: work/qemu-build/artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout cocoon-macos
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 
@@ -31,7 +31,7 @@ jobs:
         run: go build -o cocoon-macos .
 
       - name: Upload binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cocoon-macos-linux-amd64
           path: cocoon-macos

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
         run: echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout cocoon-macos
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout cocoon-macos
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload coverage artifact
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 ## Tool versions
-GOLANGCILINT_VERSION ?= v2.9.0
+GOLANGCILINT_VERSION ?= v2.12.2
 GOLANGCILINT_ROOT := $(LOCALBIN)/golangci-lint-$(GOLANGCILINT_VERSION)
 GOLANGCILINT := $(GOLANGCILINT_ROOT)/golangci-lint
 
@@ -29,7 +29,7 @@ GOIMPORTS := $(LOCALBIN)/goimports
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCILINT)
 $(GOLANGCILINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOLANGCILINT_ROOT) $(GOLANGCILINT_VERSION)
+	GOBIN=$(GOLANGCILINT_ROOT) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCILINT_VERSION)
 
 .PHONY: gofumpt
 gofumpt: $(GOFMT)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cocoonstack/cocoon-macos
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cocoonstack/cocoon v0.5.3


### PR DESCRIPTION
Part of an org-wide CI/CD refresh: pinned action versions had drifted apart across repos (checkout on v4/v5/v6, upload-artifact on v4/v6/v7), and the Go pin lagged behind the fleet.

## Actions

Each target is the current `latest` release major, read from `gh api repos/<action>/releases/latest` rather than assumed. The exact set bumped here is in the diff.

## Go

`go.mod` → 1.26.5. Every workflow resolves the toolchain through `go-version-file: go.mod`, so this single edit moves CI too.

The repo-set `go.work` moves to 1.26.5 in the same sweep (it lives outside any repo, so it is not part of this PR) — a module may not declare a newer Go than the workspace that uses it.

## Gates

`go build ./...` and `go test ./...` green locally on go1.26.5.