### PR TITLE
fix(meta): inject the json store into the cni provider

### DIFF
--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
+	metajson "github.com/cocoonstack/cocoon/meta/json"
+	"github.com/cocoonstack/cocoon/meta/tombstone"
 	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/network/bridge"
 	"github.com/cocoonstack/cocoon/network/cni"
@@ -35,7 +37,11 @@ func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
 	}
 	switch r.NetMode {
 	case netCNI:
-		return cni.New(conf)
+		store, err := metajson.Open(cniNamespace(conf))
+		if err != nil {
+			return nil, fmt.Errorf("open meta store: %w", err)
+		}
+		return cni.New(conf, store)
 	case netTAP, netBridge:
 		if r.BridgeDev == "" { // persisted at create; flag is only present on create/run/clone, not rm
 			r.BridgeDev, _ = cmd.Flags().GetString("bridge")
@@ -46,6 +52,21 @@ func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
 		return bridge.New(conf, r.BridgeDev)
 	}
 	return nil, fmt.Errorf("unknown --net mode %q (want user|tap|cni|bridge)", r.NetMode)
+}
+
+// cniNamespace mirrors cocoon's own cni json namespace (cmd/core
+// MetaJSONNamespaces) so both binaries read the same network state.
+func cniNamespace(conf *config.Config) metajson.Namespace {
+	c := cni.NewConfig(conf)
+	return metajson.Namespace{
+		Name:     cni.NamespaceName,
+		FilePath: c.IndexFile(),
+		LockPath: c.IndexLock(),
+		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
+			{Key: "networks", Table: cni.TableRecords},
+			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
+		}},
+	}
 }
 
 // provisionNet auto-creates a TAP via cocoon — the SAME forwarding plane as cocoon's CH/FC VMs.

--- a/home/home.go
+++ b/home/home.go
@@ -44,8 +44,23 @@ func VMDir(cmd *cobra.Command, name string) string {
 // OpenStore opens the cloudimg store at the resolved state dir, returning the command context with it.
 func OpenStore(cmd *cobra.Command) (context.Context, *cloudimg.CloudImg, error) {
 	ctx := cliutil.CommandContext(cmd)
-	conf := cloudimg.NewConfig(Dir(cmd), 0) // 0 = cloudimg's default pull connections
-	metaStore, err := metajson.Open(metajson.Namespace{
+	metaStore, err := metajson.Open(cloudimgNamespace(Dir(cmd)))
+	if err != nil {
+		return ctx, nil, fmt.Errorf("open meta store: %w", err)
+	}
+	s, err := cloudimg.New(ctx, Dir(cmd), 0, metaStore) // 0 = cloudimg's default pull connections
+	if err != nil {
+		return ctx, nil, fmt.Errorf("init cloudimg store: %w", err)
+	}
+	return ctx, s, nil
+}
+
+// cloudimgNamespace mirrors cocoon's own cloudimg json namespace (cmd/core
+// MetaJSONNamespaces); the layout is cocoon's, so on-disk state stays readable
+// by both binaries.
+func cloudimgNamespace(rootDir string) metajson.Namespace {
+	conf := cloudimg.NewConfig(rootDir, 0)
+	return metajson.Namespace{
 		Name:     cloudimg.NamespaceName,
 		FilePath: conf.IndexFile(),
 		LockPath: conf.IndexLock(),
@@ -53,13 +68,5 @@ func OpenStore(cmd *cobra.Command) (context.Context, *cloudimg.CloudImg, error) 
 			{Key: "images", Table: images.TableRecords},
 			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
 		}},
-	})
-	if err != nil {
-		return ctx, nil, fmt.Errorf("open meta store: %w", err)
 	}
-	s, err := cloudimg.New(ctx, Dir(cmd), 0, metaStore)
-	if err != nil {
-		return ctx, nil, fmt.Errorf("init cloudimg store: %w", err)
-	}
-	return ctx, s, nil
 }

--- a/home/home_test.go
+++ b/home/home_test.go
@@ -1,0 +1,75 @@
+package home
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon/images"
+	"github.com/cocoonstack/cocoon/images/cloudimg"
+	metajson "github.com/cocoonstack/cocoon/meta/json"
+	"github.com/cocoonstack/cocoon/meta/tombstone"
+)
+
+// TestCloudimgNamespace pins the namespace to cocoon's layout: a drifting key
+// or path would leave cocoon-written state unreadable here.
+func TestCloudimgNamespace(t *testing.T) {
+	root := t.TempDir()
+	ns := cloudimgNamespace(root)
+	conf := cloudimg.NewConfig(root, 0)
+
+	if ns.Name != cloudimg.NamespaceName {
+		t.Errorf("name = %q, want %q", ns.Name, cloudimg.NamespaceName)
+	}
+	if ns.FilePath != conf.IndexFile() {
+		t.Errorf("file = %q, want %q", ns.FilePath, conf.IndexFile())
+	}
+	if ns.LockPath != conf.IndexLock() {
+		t.Errorf("lock = %q, want %q", ns.LockPath, conf.IndexLock())
+	}
+	if got, want := filepath.Dir(ns.FilePath), filepath.Dir(ns.LockPath); got != want {
+		t.Errorf("file dir %q != lock dir %q", got, want)
+	}
+
+	codec, ok := ns.Codec.(metajson.TableCodec)
+	if !ok {
+		t.Fatalf("codec type = %T, want metajson.TableCodec", ns.Codec)
+	}
+	want := []metajson.TableSpec{
+		{Key: "images", Table: images.TableRecords},
+		{Key: "tombstones", Table: tombstone.TableName, Optional: true},
+	}
+	if len(codec.Specs) != len(want) {
+		t.Fatalf("specs = %v, want %v", codec.Specs, want)
+	}
+	for i, w := range want {
+		if codec.Specs[i] != w {
+			t.Errorf("spec[%d] = %+v, want %+v", i, codec.Specs[i], w)
+		}
+	}
+}
+
+// TestOpenStoreEmpty covers the full OpenStore path on a fresh state dir.
+func TestOpenStoreEmpty(t *testing.T) {
+	cmd := newTestCmd(t)
+	ctx, store, err := OpenStore(cmd)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	imgs, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(imgs) != 0 {
+		t.Errorf("images = %d, want 0", len(imgs))
+	}
+}
+
+func newTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("state-dir", t.TempDir(), "")
+	cmd.SetContext(t.Context())
+	return cmd
+}


### PR DESCRIPTION
cocoon v0.5.5 reworked the lock/store layer: every backend now takes an injected `meta.Store`.

`cloudimg.New` was adapted in the dep bump, but `cni.New` sits behind `//go:build linux`, so the darwin build did not catch it and master went red.

- `home.OpenStore` and the linux CNI provider each declare their namespace exactly as cocoon's own `cmd/core.MetaJSONNamespaces` does — same name, index/lock paths and table codec — so state written by either binary stays readable by the other.
- Production code depends only on `meta/json`; the heavy `cmd/core` tree (oci, firecracker, sqlite, containerregistry) is not pulled in.
- `TestCloudimgNamespace` pins the declaration. Verified it is not vacuous: mutating the `images` key to `imgs` fails the test.

Gates: `go build` darwin + linux, `go test` (darwin), `golangci-lint`.