### PR TITLE
build: consume cocoon's exported json namespace declarations

### DIFF
--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/config"
 	metajson "github.com/cocoonstack/cocoon/meta/json"
-	"github.com/cocoonstack/cocoon/meta/tombstone"
 	"github.com/cocoonstack/cocoon/network"
 	"github.com/cocoonstack/cocoon/network/bridge"
 	"github.com/cocoonstack/cocoon/network/cni"
@@ -37,7 +36,7 @@ func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
 	}
 	switch r.NetMode {
 	case netCNI:
-		store, err := metajson.Open(cniNamespace(conf))
+		store, err := metajson.Open(cni.NewConfig(conf).JSONNamespace())
 		if err != nil {
 			return nil, fmt.Errorf("open meta store: %w", err)
 		}
@@ -52,21 +51,6 @@ func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
 		return bridge.New(conf, r.BridgeDev)
 	}
 	return nil, fmt.Errorf("unknown --net mode %q (want user|tap|cni|bridge)", r.NetMode)
-}
-
-// cniNamespace mirrors cocoon's own cni json namespace (cmd/core
-// MetaJSONNamespaces) so both binaries read the same network state.
-func cniNamespace(conf *config.Config) metajson.Namespace {
-	c := cni.NewConfig(conf)
-	return metajson.Namespace{
-		Name:     cni.NamespaceName,
-		FilePath: c.IndexFile(),
-		LockPath: c.IndexLock(),
-		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
-			{Key: "networks", Table: cni.TableRecords},
-			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
-		}},
-	}
 }
 
 // provisionNet auto-creates a TAP via cocoon — the SAME forwarding plane as cocoon's CH/FC VMs.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cocoonstack/cocoon-macos
 go 1.26.5
 
 require (
-	github.com/cocoonstack/cocoon v0.5.5
+	github.com/cocoonstack/cocoon v0.5.6-0.20260723104456-be85485bbcb7
 	github.com/docker/go-units v0.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cocoonstack/cocoon v0.5.5 h1:gmyYE3ptHiwV2o2t3W0Rwx4SYA5ZAKpGmjeIMU3UPbM=
-github.com/cocoonstack/cocoon v0.5.5/go.mod h1:mpfFhJrev0f2NH80niMRIiv8OPa7ZyecyWWmIJPPK4Q=
+github.com/cocoonstack/cocoon v0.5.6-0.20260723104456-be85485bbcb7 h1:eW3FC516/2JwRZq2+ac4pA1Eo7+OTtpoOTPPppSwbNE=
+github.com/cocoonstack/cocoon v0.5.6-0.20260723104456-be85485bbcb7/go.mod h1:mpfFhJrev0f2NH80niMRIiv8OPa7ZyecyWWmIJPPK4Q=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
 github.com/containernetworking/plugins v1.9.0 h1:Mg3SXBdRGkdXyFC4lcwr6u2ZB2SDeL6LC3U+QrEANuQ=

--- a/home/home.go
+++ b/home/home.go
@@ -11,10 +11,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
-	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/images/cloudimg"
 	metajson "github.com/cocoonstack/cocoon/meta/json"
-	"github.com/cocoonstack/cocoon/meta/tombstone"
 )
 
 // Default is the state root when neither --state-dir nor $COCOON_MACOS_HOME is set.
@@ -44,7 +42,7 @@ func VMDir(cmd *cobra.Command, name string) string {
 // OpenStore opens the cloudimg store at the resolved state dir, returning the command context with it.
 func OpenStore(cmd *cobra.Command) (context.Context, *cloudimg.CloudImg, error) {
 	ctx := cliutil.CommandContext(cmd)
-	metaStore, err := metajson.Open(cloudimgNamespace(Dir(cmd)))
+	metaStore, err := metajson.Open(cloudimg.NewConfig(Dir(cmd), 0).JSONNamespace())
 	if err != nil {
 		return ctx, nil, fmt.Errorf("open meta store: %w", err)
 	}
@@ -53,20 +51,4 @@ func OpenStore(cmd *cobra.Command) (context.Context, *cloudimg.CloudImg, error) 
 		return ctx, nil, fmt.Errorf("init cloudimg store: %w", err)
 	}
 	return ctx, s, nil
-}
-
-// cloudimgNamespace mirrors cocoon's own cloudimg json namespace (cmd/core
-// MetaJSONNamespaces); the layout is cocoon's, so on-disk state stays readable
-// by both binaries.
-func cloudimgNamespace(rootDir string) metajson.Namespace {
-	conf := cloudimg.NewConfig(rootDir, 0)
-	return metajson.Namespace{
-		Name:     cloudimg.NamespaceName,
-		FilePath: conf.IndexFile(),
-		LockPath: conf.IndexLock(),
-		Codec: metajson.TableCodec{Specs: []metajson.TableSpec{
-			{Key: "images", Table: images.TableRecords},
-			{Key: tombstone.TableName, Table: tombstone.TableName, Optional: true},
-		}},
-	}
 }

--- a/home/home_test.go
+++ b/home/home_test.go
@@ -1,54 +1,10 @@
 package home
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
-
-	"github.com/cocoonstack/cocoon/images"
-	"github.com/cocoonstack/cocoon/images/cloudimg"
-	metajson "github.com/cocoonstack/cocoon/meta/json"
-	"github.com/cocoonstack/cocoon/meta/tombstone"
 )
-
-// TestCloudimgNamespace pins the namespace to cocoon's layout: a drifting key
-// or path would leave cocoon-written state unreadable here.
-func TestCloudimgNamespace(t *testing.T) {
-	root := t.TempDir()
-	ns := cloudimgNamespace(root)
-	conf := cloudimg.NewConfig(root, 0)
-
-	if ns.Name != cloudimg.NamespaceName {
-		t.Errorf("name = %q, want %q", ns.Name, cloudimg.NamespaceName)
-	}
-	if ns.FilePath != conf.IndexFile() {
-		t.Errorf("file = %q, want %q", ns.FilePath, conf.IndexFile())
-	}
-	if ns.LockPath != conf.IndexLock() {
-		t.Errorf("lock = %q, want %q", ns.LockPath, conf.IndexLock())
-	}
-	if got, want := filepath.Dir(ns.FilePath), filepath.Dir(ns.LockPath); got != want {
-		t.Errorf("file dir %q != lock dir %q", got, want)
-	}
-
-	codec, ok := ns.Codec.(metajson.TableCodec)
-	if !ok {
-		t.Fatalf("codec type = %T, want metajson.TableCodec", ns.Codec)
-	}
-	want := []metajson.TableSpec{
-		{Key: "images", Table: images.TableRecords},
-		{Key: "tombstones", Table: tombstone.TableName, Optional: true},
-	}
-	if len(codec.Specs) != len(want) {
-		t.Fatalf("specs = %v, want %v", codec.Specs, want)
-	}
-	for i, w := range want {
-		if codec.Specs[i] != w {
-			t.Errorf("spec[%d] = %+v, want %+v", i, codec.Specs[i], w)
-		}
-	}
-}
 
 // TestOpenStoreEmpty covers the full OpenStore path on a fresh state dir.
 func TestOpenStoreEmpty(t *testing.T) {


### PR DESCRIPTION
Follow-up to [cocoonstack/cocoon#165](https://github.com/cocoonstack/cocoon/pull/165), which moved the json meta namespace declarations into the backend packages that own them.

Bumps cocoon to `v0.5.6-0.20260723104456-be85485` (the merge commit) and replaces the two hand-copied `metajson.Namespace` blocks with the newly-exported methods:

- `home.OpenStore` → `cloudimg.NewConfig(...).JSONNamespace()`
- linux CNI provider → `cni.NewConfig(conf).JSONNamespace()`

Also drops `TestCloudimgNamespace`: it existed only to pin the hand-copy against cocoon's layout, and the layout can no longer diverge by construction now that both binaries obtain it from the same source. `TestOpenStoreEmpty` still exercises the full `OpenStore` path end to end.

Net -78 lines. Gates: `go build` darwin + linux, `go test` (darwin), `golangci-lint` clean on the changed files; runtime `image ls` smoke-tested against a fresh state dir.