### PR TITLE
feat: export macOS VMs as OCI cloud images

### DIFF
--- a/cmd/image/commands.go
+++ b/cmd/image/commands.go
@@ -9,6 +9,8 @@ import (
 // Actions is the image-subcommand surface, backed by cocoon's cloudimg store.
 type Actions interface {
 	Pull(cmd *cobra.Command, args []string) error
+	Import(cmd *cobra.Command, args []string) error
+	Export(cmd *cobra.Command, args []string) error
 	List(cmd *cobra.Command, args []string) error
 	Inspect(cmd *cobra.Command, args []string) error
 	RM(cmd *cobra.Command, args []string) error
@@ -25,12 +27,25 @@ func Command(h Actions) *cobra.Command {
 		RunE:  h.Pull,
 	}
 	pull.Flags().Bool("force", false, "re-pull even if already present")
+	importCmd := &cobra.Command{
+		Use:   "import NAME [FILE]",
+		Short: "Import a qcow2 cloud image from a file or stdin",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE:  h.Import,
+	}
+	exportCmd := &cobra.Command{
+		Use:   "export IMAGE",
+		Short: "Export a locally stored cloud image as qcow2",
+		Args:  cobra.ExactArgs(1),
+		RunE:  h.Export,
+	}
+	exportCmd.Flags().StringP("output", "o", "", "output file path (default: <image>.qcow2; use - for stdout)")
 
 	list := &cobra.Command{Use: "list", Aliases: []string{"ls"}, Short: "List images", RunE: h.List}
 	cliutil.AddFormatFlag(list)
 	inspect := &cobra.Command{Use: "inspect REF", Short: "Show one image (JSON)", Args: cobra.ExactArgs(1), RunE: h.Inspect}
 	rm := &cobra.Command{Use: "rm REF [REF...]", Short: "Remove image(s)", Args: cobra.MinimumNArgs(1), RunE: h.RM}
 
-	imageCmd.AddCommand(pull, list, inspect, rm)
+	imageCmd.AddCommand(pull, importCmd, exportCmd, list, inspect, rm)
 	return imageCmd
 }

--- a/cmd/image/oci.go
+++ b/cmd/image/oci.go
@@ -231,11 +231,11 @@ func pushCloudImage(ctx context.Context, target oras.Target, tag, path, title st
 		return ocispec.Descriptor{}, fmt.Errorf("check cloud image blob: %w", err)
 	}
 	if !exists {
-		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("seek cloud image: %w", err)
+		if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("seek cloud image: %w", seekErr)
 		}
-		if err := target.Push(ctx, layer, f); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("push cloud image blob: %w", err)
+		if pushErr := target.Push(ctx, layer, f); pushErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("push cloud image blob: %w", pushErr)
 		}
 	}
 

--- a/cmd/image/oci.go
+++ b/cmd/image/oci.go
@@ -8,14 +8,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
+	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
@@ -25,6 +30,11 @@ import (
 
 // pullConns is the parallel HTTP Range connection count; ghcr throttles a single stream to a fraction of the link.
 const pullConns = 8
+
+const (
+	artifactTypeOSImage = "application/vnd.cocoonstack.os-image.v1+json"
+	mediaTypeDiskQcow2  = "application/vnd.cocoonstack.disk.qcow2"
+)
 
 // pullOCIBlob downloads ref's qcow2 layer to dest and verifies its sha256 digest.
 func pullOCIBlob(ctx context.Context, ref, dest string) error {
@@ -158,6 +168,93 @@ func dockerCredential() auth.CredentialFunc {
 		return auth.StaticCredential("", auth.EmptyCredential)
 	}
 	return credentials.Credential(store)
+}
+
+// ValidatePushReference rejects digest destinations before an export stops the VM because the new manifest must be published under a tag.
+func ValidatePushReference(ref string) error {
+	_, _, err := parsePushReference(ref)
+	return err
+}
+
+// PushCloudImage publishes path as a single-layer Cocoon cloud-image artifact.
+func PushCloudImage(ctx context.Context, ref, path string, annotations map[string]string) (ocispec.Descriptor, error) {
+	repoRef, tag, err := parsePushReference(ref)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	repo, err := remote.NewRepository(repoRef)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("open repository %s: %w", repoRef, err)
+	}
+	repo.Client = &auth.Client{Cache: auth.NewCache(), Credential: dockerCredential()}
+	title := filepath.Base(repoRef) + ".qcow2"
+	return pushCloudImage(ctx, repo, tag, path, title, annotations)
+}
+
+func parsePushReference(ref string) (repo, tag string, err error) {
+	parsed, err := registry.ParseReference(ref)
+	if err != nil {
+		return "", "", fmt.Errorf("parse OCI destination %q: %w", ref, err)
+	}
+	tag = parsed.ReferenceOrDefault()
+	parsed.Reference = tag
+	if err := parsed.ValidateReferenceAsTag(); err != nil {
+		return "", "", fmt.Errorf("OCI destination %q must use a tag: %w", ref, err)
+	}
+	return parsed.Registry + "/" + parsed.Repository, tag, nil
+}
+
+func pushCloudImage(ctx context.Context, target oras.Target, tag, path, title string, annotations map[string]string) (ocispec.Descriptor, error) {
+	f, err := os.Open(path) //nolint:gosec // local VM export path
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("open cloud image: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("stat cloud image: %w", err)
+	}
+	dgst, err := digest.FromReader(f)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("hash cloud image: %w", err)
+	}
+	layer := ocispec.Descriptor{
+		MediaType: mediaTypeDiskQcow2,
+		Digest:    dgst,
+		Size:      info.Size(),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: title,
+		},
+	}
+	exists, err := target.Exists(ctx, layer)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("check cloud image blob: %w", err)
+	}
+	if !exists {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("seek cloud image: %w", err)
+		}
+		if err := target.Push(ctx, layer, f); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("push cloud image blob: %w", err)
+		}
+	}
+
+	manifestAnnotations := maps.Clone(annotations)
+	if manifestAnnotations == nil {
+		manifestAnnotations = map[string]string{}
+	}
+	manifestAnnotations["cocoonstack.disk.format"] = "qcow2"
+	manifestDesc, err := oras.PackManifest(ctx, target, oras.PackManifestVersion1_1, artifactTypeOSImage, oras.PackManifestOptions{
+		Layers:              []ocispec.Descriptor{layer},
+		ManifestAnnotations: manifestAnnotations,
+	})
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pack cloud image manifest: %w", err)
+	}
+	if err := target.Tag(ctx, manifestDesc, tag); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("tag cloud image manifest: %w", err)
+	}
+	return manifestDesc, nil
 }
 
 // pickQcow2Layer prefers the layer whose title annotation ends in .qcow2 (what `oras push` writes), else the largest.

--- a/cmd/image/oci_push_test.go
+++ b/cmd/image/oci_push_test.go
@@ -1,0 +1,82 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+type closingTarget struct {
+	oras.Target
+}
+
+func (t closingTarget) Push(ctx context.Context, expected ocispec.Descriptor, reader io.Reader) error {
+	err := t.Target.Push(ctx, expected, reader)
+	if closer, ok := reader.(io.Closer); ok {
+		_ = closer.Close()
+	}
+	return err
+}
+
+func TestPushCloudImageManifest(t *testing.T) {
+	path := t.TempDir() + "/disk.qcow2"
+	if err := os.WriteFile(path, []byte("qcow2-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := memory.New()
+	if _, err := pushCloudImage(t.Context(), store, "v1", path, "macos.qcow2", map[string]string{"cocoonstack.os.name": "macos"}); err != nil {
+		t.Fatal(err)
+	}
+	desc, err := store.Resolve(t.Context(), "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := content.FetchAll(t.Context(), store, desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ocispec.Manifest
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ArtifactType != artifactTypeOSImage || len(got.Layers) != 1 {
+		t.Fatalf("artifact=%q layers=%d", got.ArtifactType, len(got.Layers))
+	}
+	if got.Layers[0].MediaType != mediaTypeDiskQcow2 || got.Layers[0].Annotations[ocispec.AnnotationTitle] != "macos.qcow2" {
+		t.Fatalf("unexpected layer: %+v", got.Layers[0])
+	}
+}
+
+func TestPushCloudImageAllowsTargetToCloseReader(t *testing.T) {
+	path := t.TempDir() + "/disk.qcow2"
+	if err := os.WriteFile(path, []byte("qcow2-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pushCloudImage(t.Context(), closingTarget{Target: memory.New()}, "v1", path, "macos.qcow2", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidatePushReferenceRejectsDigest(t *testing.T) {
+	err := ValidatePushReference("registry.example.com/team/macos@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err == nil {
+		t.Fatal("expected digest destination to be rejected")
+	}
+}
+
+func TestParsePushReferenceDefaultsToLatest(t *testing.T) {
+	repo, tag, err := parsePushReference("registry.example.com/team/macos")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo != "registry.example.com/team/macos" || tag != "latest" {
+		t.Fatalf("repo = %q, tag = %q", repo, tag)
+	}
+}

--- a/cmd/image/transfer.go
+++ b/cmd/image/transfer.go
@@ -1,0 +1,90 @@
+package image
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/projecteru2/core/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon-macos/home"
+	"github.com/cocoonstack/cocoon/images"
+	"github.com/cocoonstack/cocoon/images/cloudimg"
+	"github.com/cocoonstack/cocoon/progress"
+)
+
+func (h *Handler) Import(cmd *cobra.Command, args []string) error {
+	ctx, store, err := home.OpenStore(cmd)
+	if err != nil {
+		return err
+	}
+	name := args[0]
+	if len(args) == 2 {
+		if err := store.Import(ctx, name, progress.Nop, args[1]); err != nil {
+			return fmt.Errorf("import %s: %w", name, err)
+		}
+		return nil
+	}
+	if err := store.ImportFromReader(ctx, name, progress.Nop, os.Stdin); err != nil {
+		return fmt.Errorf("import %s from stdin: %w", name, err)
+	}
+	return nil
+}
+
+func (h *Handler) Export(cmd *cobra.Command, args []string) (err error) {
+	ctx, store, err := home.OpenStore(cmd)
+	if err != nil {
+		return err
+	}
+	ref := args[0]
+	image, err := store.Inspect(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("export %s: %w", ref, err)
+	}
+	if image == nil {
+		return fmt.Errorf("export %s: image not found", ref)
+	}
+	digestHex := strings.TrimPrefix(image.ID, "sha256:")
+	conf := cloudimg.NewConfig(home.Dir(cmd), 0)
+	var locks images.BlobLocks
+	if err := locks.Lock(conf.BlobLockPath(digestHex)); err != nil {
+		return fmt.Errorf("lock cloud image %s: %w", ref, err)
+	}
+	defer locks.Release()
+	stream, err := os.Open(conf.BlobPath(digestHex)) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("open cloud image %s: %w", ref, err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "-" {
+		if _, err = io.Copy(os.Stdout, stream); err != nil {
+			return fmt.Errorf("write cloud image: %w", err)
+		}
+		return nil
+	}
+	if output == "" {
+		base := strings.ReplaceAll(filepath.Base(ref), ":", "-")
+		output = base + ".qcow2"
+	}
+
+	f, err := os.Create(output) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("create %s: %w", output, err)
+	}
+	defer func() {
+		_ = f.Close()
+		if err != nil {
+			_ = os.Remove(output)
+		}
+	}()
+	log.WithFunc("cmd.image.Export").Infof(ctx, "exporting %s to %s ...", ref, output)
+	if _, err = io.Copy(f, stream); err != nil {
+		return fmt.Errorf("write %s: %w", output, err)
+	}
+	return nil
+}

--- a/cmd/image/transfer.go
+++ b/cmd/image/transfer.go
@@ -50,8 +50,8 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 	digestHex := strings.TrimPrefix(image.ID, "sha256:")
 	conf := cloudimg.NewConfig(home.Dir(cmd), 0)
 	var locks images.BlobLocks
-	if err := locks.Lock(conf.BlobLockPath(digestHex)); err != nil {
-		return fmt.Errorf("lock cloud image %s: %w", ref, err)
+	if lockErr := locks.Lock(conf.BlobLockPath(digestHex)); lockErr != nil {
+		return fmt.Errorf("lock cloud image %s: %w", ref, lockErr)
 	}
 	defer locks.Release()
 	stream, err := os.Open(conf.BlobPath(digestHex)) //nolint:gosec

--- a/cmd/image/transfer.go
+++ b/cmd/image/transfer.go
@@ -34,7 +34,7 @@ func (h *Handler) Import(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (h *Handler) Export(cmd *cobra.Command, args []string) (err error) {
+func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 	ctx, store, err := home.OpenStore(cmd)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) (err error) {
 
 	output, _ := cmd.Flags().GetString("output")
 	if output == "-" {
-		if _, err = io.Copy(os.Stdout, stream); err != nil {
+		if _, err := io.Copy(os.Stdout, stream); err != nil {
 			return fmt.Errorf("write cloud image: %w", err)
 		}
 		return nil
@@ -72,19 +72,39 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) (err error) {
 		output = base + ".qcow2"
 	}
 
-	f, err := os.Create(output) //nolint:gosec
+	log.WithFunc("cmd.image.Export").Infof(ctx, "exporting %s to %s ...", ref, output)
+	return writeExportFile(output, stream)
+}
+
+// writeExportFile replaces output only after a complete, flushed copy. The
+// temporary file lives beside output so rename remains atomic.
+func writeExportFile(output string, src io.Reader) (retErr error) {
+	dir := filepath.Dir(output)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(output)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("create %s: %w", output, err)
+		return fmt.Errorf("create export temp file for %s: %w", output, err)
 	}
+	tmpPath := tmp.Name()
 	defer func() {
-		_ = f.Close()
-		if err != nil {
-			_ = os.Remove(output)
+		_ = tmp.Close()
+		if retErr != nil {
+			_ = os.Remove(tmpPath)
 		}
 	}()
-	log.WithFunc("cmd.image.Export").Infof(ctx, "exporting %s to %s ...", ref, output)
-	if _, err = io.Copy(f, stream); err != nil {
+	if _, err := io.Copy(tmp, src); err != nil {
 		return fmt.Errorf("write %s: %w", output, err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		return fmt.Errorf("chmod %s: %w", output, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync %s: %w", output, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", output, err)
+	}
+	if err := os.Rename(tmpPath, output); err != nil {
+		return fmt.Errorf("replace %s: %w", output, err)
 	}
 	return nil
 }

--- a/cmd/image/transfer_test.go
+++ b/cmd/image/transfer_test.go
@@ -1,0 +1,68 @@
+package image
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteExportFileReplacesOutputAtomically(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "image.qcow2")
+	if err := os.WriteFile(output, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeExportFile(output, strings.NewReader("new image")); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "new image" {
+		t.Fatalf("output = %q, want %q", got, "new image")
+	}
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("mode = %o, want 644", got)
+	}
+}
+
+func TestWriteExportFilePreservesExistingOutputOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "image.qcow2")
+	if err := os.WriteFile(output, []byte("valid image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeExportFile(output, io.MultiReader(strings.NewReader("partial"), failingReader{}))
+	if err == nil {
+		t.Fatal("expected copy failure")
+	}
+	data, readErr := os.ReadFile(output)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := string(data); got != "valid image" {
+		t.Fatalf("existing output changed after failure: %q", got)
+	}
+	matches, globErr := filepath.Glob(filepath.Join(dir, ".image.qcow2.tmp-*"))
+	if globErr != nil {
+		t.Fatal(globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files leaked: %v", matches)
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("injected read failure")
+}

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -19,6 +19,7 @@ type Actions interface {
 	Snapshot(cmd *cobra.Command, args []string) error
 	Restore(cmd *cobra.Command, args []string) error
 	Clone(cmd *cobra.Command, args []string) error
+	Export(cmd *cobra.Command, args []string) error
 }
 
 // Command builds the `vm` subcommand tree against the given handler.
@@ -113,9 +114,18 @@ func Command(h Actions) *cobra.Command {
 	}
 	addVMFlags(cloneCmd) // loader is inherited from SRC
 
+	exportCmd := &cobra.Command{
+		Use:   "export VM REF",
+		Short: "Stop, flatten, restart, and publish a VM as a qcow2 OCI artifact",
+		Args:  cobra.ExactArgs(2),
+		RunE:  h.Export,
+	}
+	exportCmd.Flags().Int("vnc", -1, "VNC display number for the restarted VM; omit to preserve the current display")
+	exportCmd.Flags().String("vnc-password", "", "VNC password for the restarted VM; omit to preserve the in-memory password when available (required with CNI VNC)")
+
 	vmCmd.AddCommand(vncProxyCommand())
 	vmCmd.AddCommand(createCmd, runCmd, startCmd, stopCmd, listCmd, inspectCmd, consoleCmd, rmCmd,
-		snapshotCmd, restoreCmd, cloneCmd)
+		snapshotCmd, restoreCmd, cloneCmd, exportCmd)
 	return vmCmd
 }
 

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -122,6 +122,7 @@ func Command(h Actions) *cobra.Command {
 	}
 	exportCmd.Flags().Int("vnc", -1, "VNC display number for the restarted VM; omit to preserve the current display")
 	exportCmd.Flags().String("vnc-password", "", "VNC password for the restarted VM; omit to preserve the in-memory password when available (required with CNI VNC)")
+	exportCmd.Flags().String("local-name", "", "also retain the exported qcow2 in the local cloud-image store under this name")
 
 	vmCmd.AddCommand(vncProxyCommand())
 	vmCmd.AddCommand(createCmd, runCmd, startCmd, stopCmd, listCmd, inspectCmd, consoleCmd, rmCmd,

--- a/cmd/vm/export.go
+++ b/cmd/vm/export.go
@@ -12,6 +12,7 @@ import (
 	cmdimage "github.com/cocoonstack/cocoon-macos/cmd/image"
 	"github.com/cocoonstack/cocoon-macos/home"
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	"github.com/cocoonstack/cocoon/progress"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
@@ -83,6 +84,16 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("push cloud image: %w", err)
 	}
 	fmt.Println(desc.Digest)
+	localName, _ := cmd.Flags().GetString("local-name")
+	if localName != "" {
+		_, store, openErr := home.OpenStore(cmd)
+		if openErr != nil {
+			return fmt.Errorf("open local cloud-image store: %w", openErr)
+		}
+		if importErr := store.Import(ctx, localName, progress.Nop, tmpPath); importErr != nil {
+			return fmt.Errorf("retain local cloud image %s: %w", localName, importErr)
+		}
+	}
 	return nil
 }
 

--- a/cmd/vm/export.go
+++ b/cmd/vm/export.go
@@ -1,0 +1,98 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cmdimage "github.com/cocoonstack/cocoon-macos/cmd/image"
+	"github.com/cocoonstack/cocoon-macos/home"
+	"github.com/cocoonstack/cocoon/cmd/cliutil"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+const exportRestartTimeout = 2 * time.Minute
+
+func (h *Handler) Export(cmd *cobra.Command, args []string) error {
+	ctx := cliutil.CommandContext(cmd)
+	vmName, destination := args[0], args[1]
+	if err := cmdimage.ValidatePushReference(destination); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(home.Dir(cmd), ".cocoon-macos-export-*.qcow2")
+	if err != nil {
+		return fmt.Errorf("create export temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close export temp file: %w", err)
+	}
+	defer os.Remove(tmpPath) //nolint:errcheck
+
+	dir := home.VMDir(cmd, vmName)
+	if err := withVMLock(ctx, dir, func() (retErr error) {
+		r, err := loadRec(dir)
+		if err != nil {
+			return err
+		}
+		wasRunning := isRunning(r)
+		restartVNC, restartVNCPass := exportRestartVNC(cmd, r)
+		if wasRunning {
+			if err := requireCNIVNCPassword(r.Netns != "", restartVNC, restartVNCPass); err != nil {
+				return fmt.Errorf("restart settings: %w", err)
+			}
+			terminate(ctx, r, stopGracePeriod)
+			if isRunning(r) {
+				return fmt.Errorf("VM %s is still running after shutdown", vmName)
+			}
+			quiesceNet(cmd, r)
+			stopVNCProxy(ctx, dir)
+			r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
+			defer func() {
+				restartCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), exportRestartTimeout)
+				defer cancel()
+				restartCmd := *cmd
+				restartCmd.SetContext(restartCtx)
+				r.VNCDisp, r.VNCPass = restartVNC, restartVNCPass
+				restartErr := h.launch(&restartCmd, dir, r)
+				if isRunning(r) {
+					unquiesceNet(&restartCmd, r)
+				}
+				retErr = errors.Join(retErr, restartErr)
+			}()
+			if err := saveRec(dir, r); err != nil {
+				return err
+			}
+		}
+
+		return utils.RunQemuImg(ctx, "convert", "-p", "-f", "qcow2", "-O", "qcow2", "-c", r.Disk, tmpPath)
+	}); err != nil {
+		return fmt.Errorf("export VM %s: %w", vmName, err)
+	}
+
+	desc, err := cmdimage.PushCloudImage(ctx, destination, tmpPath, map[string]string{
+		"cocoonstack.os.name":   "macos",
+		"cocoonstack.source.vm": vmName,
+	})
+	if err != nil {
+		return fmt.Errorf("push cloud image: %w", err)
+	}
+	fmt.Println(desc.Digest)
+	return nil
+}
+
+func exportRestartVNC(cmd *cobra.Command, r *record) (int, string) {
+	vnc, password := r.VNCDisp, r.VNCPass
+	if cmd.Flags().Changed("vnc") {
+		vnc, _ = cmd.Flags().GetInt("vnc")
+	}
+	if cmd.Flags().Changed("vnc-password") {
+		password, _ = cmd.Flags().GetString("vnc-password")
+	}
+	return vnc, password
+}

--- a/cmd/vm/export.go
+++ b/cmd/vm/export.go
@@ -29,23 +29,23 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create export temp file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	if err := tmp.Close(); err != nil {
+	if closeErr := tmp.Close(); closeErr != nil {
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("close export temp file: %w", err)
+		return fmt.Errorf("close export temp file: %w", closeErr)
 	}
 	defer os.Remove(tmpPath) //nolint:errcheck
 
 	dir := home.VMDir(cmd, vmName)
-	if err := withVMLock(ctx, dir, func() (retErr error) {
-		r, err := loadRec(dir)
-		if err != nil {
-			return err
+	if exportErr := withVMLock(ctx, dir, func() (retErr error) {
+		r, loadErr := loadRec(dir)
+		if loadErr != nil {
+			return loadErr
 		}
 		wasRunning := isRunning(r)
 		restartVNC, restartVNCPass := exportRestartVNC(cmd, r)
 		if wasRunning {
-			if err := requireCNIVNCPassword(r.Netns != "", restartVNC, restartVNCPass); err != nil {
-				return fmt.Errorf("restart settings: %w", err)
+			if validationErr := requireCNIVNCPassword(r.Netns != "", restartVNC, restartVNCPass); validationErr != nil {
+				return fmt.Errorf("restart settings: %w", validationErr)
 			}
 			terminate(ctx, r, stopGracePeriod)
 			if isRunning(r) {
@@ -66,14 +66,14 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 				}
 				retErr = errors.Join(retErr, restartErr)
 			}()
-			if err := saveRec(dir, r); err != nil {
-				return err
+			if saveErr := saveRec(dir, r); saveErr != nil {
+				return saveErr
 			}
 		}
 
 		return utils.RunQemuImg(ctx, "convert", "-p", "-f", "qcow2", "-O", "qcow2", "-c", r.Disk, tmpPath)
-	}); err != nil {
-		return fmt.Errorf("export VM %s: %w", vmName, err)
+	}); exportErr != nil {
+		return fmt.Errorf("export VM %s: %w", vmName, exportErr)
 	}
 
 	desc, err := cmdimage.PushCloudImage(ctx, destination, tmpPath, map[string]string{

--- a/cmd/vm/export.go
+++ b/cmd/vm/export.go
@@ -83,7 +83,6 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("push cloud image: %w", err)
 	}
-	fmt.Println(desc.Digest)
 	localName, _ := cmd.Flags().GetString("local-name")
 	if localName != "" {
 		_, store, openErr := home.OpenStore(cmd)
@@ -91,9 +90,10 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("open local cloud-image store: %w", openErr)
 		}
 		if importErr := store.Import(ctx, localName, progress.Nop, tmpPath); importErr != nil {
-			return fmt.Errorf("retain local cloud image %s: %w", localName, importErr)
+			return fmt.Errorf("pushed %s as %s, but retaining local cloud image %s failed: %w", destination, desc.Digest, localName, importErr)
 		}
 	}
+	fmt.Println(desc.Digest)
 	return nil
 }
 

--- a/cmd/vm/export.go
+++ b/cmd/vm/export.go
@@ -87,7 +87,7 @@ func (h *Handler) Export(cmd *cobra.Command, args []string) error {
 	if localName != "" {
 		_, store, openErr := home.OpenStore(cmd)
 		if openErr != nil {
-			return fmt.Errorf("open local cloud-image store: %w", openErr)
+			return fmt.Errorf("pushed %s as %s, but opening the local cloud-image store failed: %w", destination, desc.Digest, openErr)
 		}
 		if importErr := store.Import(ctx, localName, progress.Nop, tmpPath); importErr != nil {
 			return fmt.Errorf("pushed %s as %s, but retaining local cloud image %s failed: %w", destination, desc.Digest, localName, importErr)

--- a/cmd/vm/export_test.go
+++ b/cmd/vm/export_test.go
@@ -1,0 +1,35 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExportRestartVNCPreservesCurrentDisplay(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("vnc", -1, "")
+	cmd.Flags().String("vnc-password", "", "")
+
+	vnc, password := exportRestartVNC(cmd, &record{VNCDisp: 3, VNCPass: "secret"})
+	if vnc != 3 || password != "secret" {
+		t.Fatalf("restart VNC = (%d, %q), want (3, secret)", vnc, password)
+	}
+}
+
+func TestExportRestartVNCUsesExplicitOverrides(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Int("vnc", -1, "")
+	cmd.Flags().String("vnc-password", "", "")
+	if err := cmd.Flags().Set("vnc", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("vnc-password", "newpass"); err != nil {
+		t.Fatal(err)
+	}
+
+	vnc, password := exportRestartVNC(cmd, &record{VNCDisp: 3, VNCPass: "oldpass"})
+	if vnc != 1 || password != "newpass" {
+		t.Fatalf("restart VNC = (%d, %q), want (1, newpass)", vnc, password)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,7 +76,8 @@ extend VM downtime.
 
 Use `--local-name NAME` to register the flattened qcow2 in the local cloud-image
 store after a successful push. Later runs on the source node can then reuse it
-without downloading it from the registry.
+without downloading it from the registry. A local-retention failure does not roll
+back the already published OCI artifact; the error reports its manifest digest.
 
 The current VNC display is preserved when the VM is restarted. VNC credentials are
 intentionally not persisted, so a CNI VM whose password is no longer available must

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,10 @@ restarts the VM, then uploads the standalone disk as
 standard Docker config. Upload happens after restart, so registry latency does not
 extend VM downtime.
 
+Use `--local-name NAME` to register the flattened qcow2 in the local cloud-image
+store after a successful push. Later runs on the source node can then reuse it
+without downloading it from the registry.
+
 The current VNC display is preserved when the VM is restarted. VNC credentials are
 intentionally not persisted, so a CNI VM whose password is no longer available must
 pass `--vnc N --vnc-password PASSWORD`. Pass `--vnc -1` to disable VNC after the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ cocoon-macos vm run ghcr.io/cocoonstack/cocoon-macos/tahoe:26 \
 cocoon-macos vm list           # table (NAME STATE CPU MEM NET VNC SSH IMAGE CREATED); -o json for JSON
 cocoon-macos vm inspect m1     # full record as JSON
 cocoon-macos vm stop m1
+cocoon-macos vm export m1 registry.example.com/team/macos-custom:v1
 cocoon-macos vm rm m1
 # also: create (no boot), start, console
 ```
@@ -60,3 +61,20 @@ over.
 
 State is recorded under `--state-dir` / `$COCOON_MACOS_HOME` (default `/var/lib/cocoon-macos`).
 `$COCOON_MACOS_LOG_LEVEL` sets the log level (`debug` / `info` / `warn` / `error`, default `info`).
+
+## Export a custom image
+
+```bash
+cocoon-macos vm export m1 registry.example.com/team/macos-custom:v1
+```
+
+The command stops a running VM, flattens and compresses its qcow2 backing chain,
+restarts the VM, then uploads the standalone disk as
+`application/vnd.cocoonstack.os-image.v1+json`. Registry credentials come from the
+standard Docker config. Upload happens after restart, so registry latency does not
+extend VM downtime.
+
+The current VNC display is preserved when the VM is restarted. VNC credentials are
+intentionally not persisted, so a CNI VM whose password is no longer available must
+pass `--vnc N --vnc-password PASSWORD`. Pass `--vnc -1` to disable VNC after the
+export. A VM that was already stopped remains stopped.

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,5 +1,13 @@
 # Images
 
+Local cloud images can be streamed between compatible macOS nodes without an
+intermediate file:
+
+```bash
+cocoon-macos image export custom-macos-66:tag -o - | \
+  ssh node2 cocoon-macos image import custom-macos-66:tag
+```
+
 ## Golden images on ghcr
 
 The CI pipeline (see [CI Image Pipeline](image-pipeline.md)) publishes two tiers per OS:

--- a/docs/images.md
+++ b/docs/images.md
@@ -38,3 +38,10 @@ verifies the SHA-256 against the layer digest before importing:
   up to 3 times on transient drops.
 
 This is both faster (parallel chunks saturate the link) and more robust than a single stream.
+
+## Publishing VM disks
+
+`cocoon-macos vm export VM REF` publishes a flattened VM root disk using the same
+OCI cloud-image artifact type consumed by `image pull`. It writes one
+`application/vnd.cocoonstack.disk.qcow2` layer and authenticates through the Docker
+credential store; no external `oras` binary is required.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/cocoonstack/cocoon v0.5.10-0.20260817090435-cde2318b40d9
 	github.com/docker/go-units v0.5.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projecteru2/core v0.0.0-20241016125006-ff909eefe04c
 	github.com/spf13/cobra v1.10.2
@@ -35,7 +36,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.27.4 // indirect
 	github.com/onsi/gomega v1.39.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect


### PR DESCRIPTION
## Summary

- export a macOS VM root disk as a standalone OCI cloud-image artifact
- add local cloud-image import/export for host-to-host transfer
- expose the related `image` and `vm export` commands
- preserve an existing output file when a local export fails
- report remote publication explicitly when optional local retention fails

## Lifecycle behavior

The destination is validated before the VM is stopped. A running VM is stopped under its lifecycle lock, flattened, and restarted before the registry upload begins, so upload latency does not extend downtime. A VM that was already stopped remains stopped.

Temporary files are synchronized before atomic replacement, and successful OCI publication is not misreported as a total failure if only the optional local retain step fails.

## Merge ordering

[#30](https://github.com/cocoonstack/cocoon-macos/pull/30) should land first. It makes a queued `vm start` idempotent when export has already restarted QEMU and restores a missing VNC proxy without restarting a healthy guest.

## Validation

- `make lint`
- `go test ./...`