### PR TITLE
fix: reject unsupported odd macOS CPU counts

### DIFF
--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -28,6 +28,13 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if err = requireCNIVNCPassword(netMode == netCNI, vnc, vncPass); err != nil {
 		return err
 	}
+	cpus := srcRec.CPUs
+	if cmd.Flags().Changed("cpus") {
+		cpus, _ = cmd.Flags().GetInt("cpus")
+	}
+	if err = validateMacOSCPUs(cpus); err != nil {
+		return err
+	}
 	// SRC's disk names are reserved: extra --data-disk specs must not collide and the combined count still honors the AHCI cap
 	reserved := make([]string, len(srcRec.DataDisks))
 	for i, p := range srcRec.DataDisks {
@@ -53,12 +60,9 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	}
 	r := &record{
 		Name: name, Image: srcRec.Image, ImageDigest: digest, Disk: overlay,
-		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: srcRec.CPUs, Memory: srcRec.Memory,
+		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: cpus, Memory: srcRec.Memory,
 		DataDisks: append(copied, newDisks...),
 		VMID:      utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
-	}
-	if cmd.Flags().Changed("cpus") {
-		r.CPUs, _ = cmd.Flags().GetInt("cpus")
 	}
 	if cmd.Flags().Changed("memory") {
 		r.Memory, _ = cmd.Flags().GetString("memory")

--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -2,10 +2,33 @@ package vm
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestValidateMacOSCPUs(t *testing.T) {
+	for _, tt := range []struct {
+		cpus    int
+		wantErr bool
+	}{
+		{cpus: -2, wantErr: true},
+		{cpus: 0, wantErr: true},
+		{cpus: 1, wantErr: true},
+		{cpus: 2},
+		{cpus: 3, wantErr: true},
+		{cpus: 4},
+	} {
+		err := validateMacOSCPUs(tt.cpus)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("validateMacOSCPUs(%d) error = %v, wantErr %v", tt.cpus, err, tt.wantErr)
+		}
+		if err != nil && !strings.Contains(err.Error(), "positive even number") {
+			t.Fatalf("validateMacOSCPUs(%d) error = %v", tt.cpus, err)
+		}
+	}
+}
 
 func TestCloneOpenCoreBase(t *testing.T) {
 	tests := []struct {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -126,6 +126,10 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if err != nil {
 		return nil, err
 	}
+	cpus, _ := cmd.Flags().GetInt("cpus")
+	if cpus < 1 {
+		return nil, fmt.Errorf("--cpus must be at least 1, got %d", cpus)
+	}
 	vnc, _ := cmd.Flags().GetInt("vnc")
 	vncPass, _ := cmd.Flags().GetString("vnc-password")
 	netMode, _ := cmd.Flags().GetString("net")
@@ -141,7 +145,6 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 		return nil, err
 	}
 	ctx := cliutil.CommandContext(cmd)
-	cpus, _ := cmd.Flags().GetInt("cpus")
 	mem, _ := cmd.Flags().GetString("memory")
 	ssh, _ := cmd.Flags().GetInt("ssh-port")
 	tap, _ := cmd.Flags().GetString("tap")
@@ -188,9 +191,6 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 	// CNI: a 127.0.0.1 VNC inside the netns is unreachable; use a unix socket fronted by startVNCProxy
 	if r.Netns != "" && r.VNCDisp >= 0 {
 		spec.VNCSock = filepath.Join(dir, vncSockName)
-	}
-	if err := spec.Validate(); err != nil {
-		return fmt.Errorf("invalid macOS VM resources: %w", err)
 	}
 	pidfile := filepath.Join(dir, "qemu.pid")
 	args := append(spec.Args(), "-daemonize", "-pidfile", pidfile)

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -189,6 +189,9 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 	if r.Netns != "" && r.VNCDisp >= 0 {
 		spec.VNCSock = filepath.Join(dir, vncSockName)
 	}
+	if err := spec.Validate(); err != nil {
+		return fmt.Errorf("invalid macOS VM resources: %w", err)
+	}
 	pidfile := filepath.Join(dir, "qemu.pid")
 	args := append(spec.Args(), "-daemonize", "-pidfile", pidfile)
 	ensureNetnsLoopback(ctx, r) // CNI: a fresh netns has lo DOWN, so qemu's -vnc 127.0.0.1 would fail to bind

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -127,8 +127,8 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 		return nil, err
 	}
 	cpus, _ := cmd.Flags().GetInt("cpus")
-	if cpus < 1 {
-		return nil, fmt.Errorf("--cpus must be at least 1, got %d", cpus)
+	if err = validateMacOSCPUs(cpus); err != nil {
+		return nil, err
 	}
 	vnc, _ := cmd.Flags().GetInt("vnc")
 	vncPass, _ := cmd.Flags().GetString("vnc-password")
@@ -166,6 +166,13 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 		return nil, err
 	}
 	return r, saveRec(dir, r)
+}
+
+func validateMacOSCPUs(cpus int) error {
+	if cpus < 1 || cpus%2 != 0 {
+		return fmt.Errorf("--cpus must be a positive even number, got %d", cpus)
+	}
+	return nil
 }
 
 func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -12,7 +12,8 @@ Every VM boots the same way on Intel and AMD:
   baked into the macOS qcow2 — the same image boots under a different loader on Intel vs AMD.
 - **CPU:** `Skylake-Client` spoofing `GenuineIntel` with `-hle,-rtm` (TSX off), `+invtsc`, and
   `vmware-cpuid-freq=on`. The TSC flags are load-bearing: without them macOS self-calibrates the TSC
-  and spins pathologically under nested KVM on first boot.
+  and spins pathologically under nested KVM on first boot. QEMU receives an explicit one-thread-per-core
+  topology so odd vCPU counts do not get inferred as unsupported multi-threaded cores.
 - **OpenCore picker:** the shipped `OpenCore.qcow2` template boots the default entry immediately with
   no picker UI (a visible picker can't be driven reliably headlessly — OpenCanopy cancels its
   `Timeout` countdown on stray USB-enumeration input and then waits forever). `--random-smbios`

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -12,8 +12,8 @@ Every VM boots the same way on Intel and AMD:
   baked into the macOS qcow2 — the same image boots under a different loader on Intel vs AMD.
 - **CPU:** `Skylake-Client` spoofing `GenuineIntel` with `-hle,-rtm` (TSX off), `+invtsc`, and
   `vmware-cpuid-freq=on`. The TSC flags are load-bearing: without them macOS self-calibrates the TSC
-  and spins pathologically under nested KVM on first boot. QEMU receives an explicit one-thread-per-core
-  topology so odd vCPU counts do not get inferred as unsupported multi-threaded cores.
+  and spins pathologically under nested KVM on first boot. `--cpus` must be a positive even number;
+  create/run/clone reject odd counts before VM state is created because this macOS stack does not boot them.
 - **OpenCore picker:** the shipped `OpenCore.qcow2` template boots the default entry immediately with
   no picker UI (a visible picker can't be driven reliably headlessly — OpenCanopy cancels its
   `Timeout` countdown on stray USB-enumeration input and then waits forever). `--random-smbios`

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -43,12 +43,10 @@ type Spec struct {
 	QMPSock string
 }
 
-// Validate rejects CPU topologies that QEMU would otherwise silently expand
-// into unsupported SMT shapes. macOS expects two threads per virtual core, so
-// the vCPU count must be a positive even number.
+// Validate rejects invalid CPU counts before QEMU builds the topology.
 func (s Spec) Validate() error {
-	if s.CPUs < 2 || s.CPUs%2 != 0 {
-		return fmt.Errorf("cpus must be an even number greater than or equal to 2: %d", s.CPUs)
+	if s.CPUs < 1 {
+		return fmt.Errorf("cpus must be greater than zero: %d", s.CPUs)
 	}
 	return nil
 }
@@ -56,7 +54,6 @@ func (s Spec) Validate() error {
 // Args returns the qemu-system-x86_64 argument vector for the macOS guest.
 // Callers must validate the spec before launching QEMU.
 func (s Spec) Args() []string {
-	cores := s.CPUs / 2
 	varsFmt := "raw"
 	if IsQcow2NVRAM(s.OVMFVars) {
 		varsFmt = "qcow2"
@@ -72,7 +69,10 @@ func (s Spec) Args() []string {
 		"-enable-kvm", "-m", s.Memory,
 		"-cpu", macOSCPU,
 		"-machine", machine,
-		"-smp", fmt.Sprintf("%d,cores=%d,threads=2,sockets=1", s.CPUs, cores),
+		// Declare every topology dimension. Leaving threads implicit lets QEMU
+		// derive surprising SMT layouts (for example, 3 threads on one core for
+		// 3 vCPUs), which macOS may boot very slowly or fail to initialize.
+		"-smp", fmt.Sprintf("%d,cores=%d,threads=1,sockets=1", s.CPUs, s.CPUs),
 		"-device", "qemu-xhci,id=xhci",
 		"-device", "usb-kbd,bus=xhci.0",
 		"-device", "usb-tablet,bus=xhci.0",

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -43,16 +43,7 @@ type Spec struct {
 	QMPSock string
 }
 
-// Validate rejects invalid CPU counts before QEMU builds the topology.
-func (s Spec) Validate() error {
-	if s.CPUs < 1 {
-		return fmt.Errorf("cpus must be greater than zero: %d", s.CPUs)
-	}
-	return nil
-}
-
 // Args returns the qemu-system-x86_64 argument vector for the macOS guest.
-// Callers must validate the spec before launching QEMU.
 func (s Spec) Args() []string {
 	varsFmt := "raw"
 	if IsQcow2NVRAM(s.OVMFVars) {
@@ -69,9 +60,7 @@ func (s Spec) Args() []string {
 		"-enable-kvm", "-m", s.Memory,
 		"-cpu", macOSCPU,
 		"-machine", machine,
-		// Declare every topology dimension. Leaving threads implicit lets QEMU
-		// derive surprising SMT layouts (for example, 3 threads on one core for
-		// 3 vCPUs), which macOS may boot very slowly or fail to initialize.
+		// Implicit threads lets QEMU infer SMT layouts (3 vCPUs -> 1 core x 3 threads) that macOS boots slowly or not at all.
 		"-smp", fmt.Sprintf("%d,cores=%d,threads=1,sockets=1", s.CPUs, s.CPUs),
 		"-device", "qemu-xhci,id=xhci",
 		"-device", "usb-kbd,bus=xhci.0",

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -45,6 +45,7 @@ type Spec struct {
 
 // Args returns the qemu-system-x86_64 argument vector for the macOS guest.
 func (s Spec) Args() []string {
+	cores := max(s.CPUs/2, 1)
 	varsFmt := "raw"
 	if IsQcow2NVRAM(s.OVMFVars) {
 		varsFmt = "qcow2"
@@ -60,8 +61,7 @@ func (s Spec) Args() []string {
 		"-enable-kvm", "-m", s.Memory,
 		"-cpu", macOSCPU,
 		"-machine", machine,
-		// Implicit threads lets QEMU infer SMT layouts (3 vCPUs -> 1 core x 3 threads) that macOS boots slowly or not at all.
-		"-smp", fmt.Sprintf("%d,cores=%d,threads=1,sockets=1", s.CPUs, s.CPUs),
+		"-smp", fmt.Sprintf("%d,cores=%d,sockets=1", s.CPUs, cores),
 		"-device", "qemu-xhci,id=xhci",
 		"-device", "usb-kbd,bus=xhci.0",
 		"-device", "usb-tablet,bus=xhci.0",

--- a/qemu/launch.go
+++ b/qemu/launch.go
@@ -43,9 +43,20 @@ type Spec struct {
 	QMPSock string
 }
 
+// Validate rejects CPU topologies that QEMU would otherwise silently expand
+// into unsupported SMT shapes. macOS expects two threads per virtual core, so
+// the vCPU count must be a positive even number.
+func (s Spec) Validate() error {
+	if s.CPUs < 2 || s.CPUs%2 != 0 {
+		return fmt.Errorf("cpus must be an even number greater than or equal to 2: %d", s.CPUs)
+	}
+	return nil
+}
+
 // Args returns the qemu-system-x86_64 argument vector for the macOS guest.
+// Callers must validate the spec before launching QEMU.
 func (s Spec) Args() []string {
-	cores := max(s.CPUs/2, 1)
+	cores := s.CPUs / 2
 	varsFmt := "raw"
 	if IsQcow2NVRAM(s.OVMFVars) {
 		varsFmt = "qcow2"
@@ -61,7 +72,7 @@ func (s Spec) Args() []string {
 		"-enable-kvm", "-m", s.Memory,
 		"-cpu", macOSCPU,
 		"-machine", machine,
-		"-smp", fmt.Sprintf("%d,cores=%d,sockets=1", s.CPUs, cores),
+		"-smp", fmt.Sprintf("%d,cores=%d,threads=2,sockets=1", s.CPUs, cores),
 		"-device", "qemu-xhci,id=xhci",
 		"-device", "usb-kbd,bus=xhci.0",
 		"-device", "usb-tablet,bus=xhci.0",

--- a/qemu/launch_test.go
+++ b/qemu/launch_test.go
@@ -132,6 +132,9 @@ func TestArgsHugepages(t *testing.T) {
 
 func TestArgsCPU(t *testing.T) {
 	s := Spec{Disk: "/v/d.qcow2", OpenCore: "/v/oc.qcow2", OVMFCode: "/v/c.fd", OVMFVars: "/v/v.fd", CPUs: 4, Memory: "4096", VNCDisp: -1}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("valid CPU topology rejected: %v", err)
+	}
 	cpu := argVals(s.Args(), "-cpu")
 	if len(cpu) != 1 {
 		t.Fatalf("-cpu count: %v", cpu)
@@ -147,6 +150,14 @@ func TestArgsCPU(t *testing.T) {
 		if !strings.Contains(cpu[0], f) {
 			t.Fatalf("-cpu missing load-bearing %s: %s", f, cpu[0])
 		}
+	}
+	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "4,cores=2,threads=2,sockets=1" {
+		t.Fatalf("unexpected CPU topology: %v", got)
+	}
+
+	s.CPUs = 3
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "even number") {
+		t.Fatalf("odd CPU topology must be rejected, got %v", err)
 	}
 }
 

--- a/qemu/launch_test.go
+++ b/qemu/launch_test.go
@@ -151,13 +151,21 @@ func TestArgsCPU(t *testing.T) {
 			t.Fatalf("-cpu missing load-bearing %s: %s", f, cpu[0])
 		}
 	}
-	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "4,cores=2,threads=2,sockets=1" {
+	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "4,cores=4,threads=1,sockets=1" {
 		t.Fatalf("unexpected CPU topology: %v", got)
 	}
 
 	s.CPUs = 3
-	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "even number") {
-		t.Fatalf("odd CPU topology must be rejected, got %v", err)
+	if err := s.Validate(); err != nil {
+		t.Fatalf("odd CPU counts are valid with an explicit single-thread topology: %v", err)
+	}
+	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "3,cores=3,threads=1,sockets=1" {
+		t.Fatalf("unexpected odd CPU topology: %v", got)
+	}
+
+	s.CPUs = 0
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "greater than zero") {
+		t.Fatalf("zero CPUs must be rejected, got %v", err)
 	}
 }
 

--- a/qemu/launch_test.go
+++ b/qemu/launch_test.go
@@ -132,9 +132,6 @@ func TestArgsHugepages(t *testing.T) {
 
 func TestArgsCPU(t *testing.T) {
 	s := Spec{Disk: "/v/d.qcow2", OpenCore: "/v/oc.qcow2", OVMFCode: "/v/c.fd", OVMFVars: "/v/v.fd", CPUs: 4, Memory: "4096", VNCDisp: -1}
-	if err := s.Validate(); err != nil {
-		t.Fatalf("valid CPU topology rejected: %v", err)
-	}
 	cpu := argVals(s.Args(), "-cpu")
 	if len(cpu) != 1 {
 		t.Fatalf("-cpu count: %v", cpu)
@@ -156,16 +153,8 @@ func TestArgsCPU(t *testing.T) {
 	}
 
 	s.CPUs = 3
-	if err := s.Validate(); err != nil {
-		t.Fatalf("odd CPU counts are valid with an explicit single-thread topology: %v", err)
-	}
 	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "3,cores=3,threads=1,sockets=1" {
 		t.Fatalf("unexpected odd CPU topology: %v", got)
-	}
-
-	s.CPUs = 0
-	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "greater than zero") {
-		t.Fatalf("zero CPUs must be rejected, got %v", err)
 	}
 }
 

--- a/qemu/launch_test.go
+++ b/qemu/launch_test.go
@@ -148,13 +148,13 @@ func TestArgsCPU(t *testing.T) {
 			t.Fatalf("-cpu missing load-bearing %s: %s", f, cpu[0])
 		}
 	}
-	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "4,cores=4,threads=1,sockets=1" {
+	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "4,cores=2,sockets=1" {
 		t.Fatalf("unexpected CPU topology: %v", got)
 	}
 
-	s.CPUs = 3
-	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "3,cores=3,threads=1,sockets=1" {
-		t.Fatalf("unexpected odd CPU topology: %v", got)
+	s.CPUs = 2
+	if got := argVals(s.Args(), "-smp"); len(got) != 1 || got[0] != "2,cores=1,sockets=1" {
+		t.Fatalf("unexpected two-vCPU topology: %v", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Bare-metal A/B testing showed that odd vCPU counts do not boot on this macOS QEMU/OpenCore stack. Making QEMU accept an odd topology only changes the failure from a launch error to a guest that hangs before SSH. The previous even-vCPU topology already boots and must remain unchanged.

## Fix

- require a positive even `--cpus` value for create/run/clone
- reject unsupported counts before VM state or disks are created
- preserve the existing `cores=max(N/2,1)` QEMU topology for supported even counts
- keep CPU validation at the CLI boundary rather than adding it to `qemu.Spec`

## Validation

- `go test ./...`
- `make fmt-check vet lint`
- maintainer A/B on host `.79`, QEMU 8.2.2, macOS Sequoia 15:
  - old 4 vCPU topology (`4,cores=2,sockets=1`): booted to SSH in 21s
  - proposed 4c1t topology: booted in 25s but changed guest-visible topology
  - both tested 3-vCPU layouts failed to reach SSH; 5-vCPU 5c1t also failed
