### PR TITLE
fix: make macOS start idempotent and repair VNC proxy

### DIFF
--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,8 +41,7 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Give isRunning a real process whose argv[0] and arguments match the
-	// qemu identity check without requiring qemu or KVM in the unit test.
+	// A real process whose argv0+args satisfy isRunning without qemu/KVM.
 	fakeQEMU := filepath.Join(t.TempDir(), qemuBinary)
 	if err := os.Symlink("/bin/sh", fakeQEMU); err != nil {
 		t.Fatal(err)
@@ -73,8 +73,14 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewHandler().Start(cmd, []string{"macos-demo"}); err != nil {
+	output, err := captureStdout(t, func() error {
+		return NewHandler().Start(cmd, []string{"macos-demo"})
+	})
+	if err != nil {
 		t.Fatalf("duplicate start must adopt the live qemu: %v", err)
+	}
+	if !strings.Contains(output, "supplied VNC settings ignored because live QEMU cannot be retargeted") {
+		t.Fatalf("duplicate start output = %q, want ignored VNC settings warning", output)
 	}
 	got, err := loadRec(vmDir)
 	if err != nil {
@@ -83,6 +89,29 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 	if got.PID != rec.PID || got.VNCDisp != 1 {
 		t.Fatalf("live record changed: pid=%d vnc=%d, want pid=%d vnc=1", got.PID, got.VNCDisp, rec.PID)
 	}
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	callErr := fn()
+	os.Stdout = original
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output), callErr
 }
 
 func TestCloneOpenCoreBase(t *testing.T) {

--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -1,6 +1,9 @@
 package vm
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -27,6 +30,58 @@ func TestValidateMacOSCPUs(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), "positive even number") {
 			t.Fatalf("validateMacOSCPUs(%d) error = %v", tt.cpus, err)
 		}
+	}
+}
+
+func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
+	stateDir := t.TempDir()
+	vmDir := filepath.Join(stateDir, "vms", "macos-demo")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give isRunning a real process whose argv[0] and arguments match the
+	// qemu identity check without requiring qemu or KVM in the unit test.
+	fakeQEMU := filepath.Join(t.TempDir(), qemuBinary)
+	if err := os.Symlink("/bin/sh", fakeQEMU); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vmDir, "disk.qcow2")
+	process := exec.Command(fakeQEMU, "-c", "sleep 60", disk)
+	if err := process.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = process.Process.Kill()
+		_ = process.Wait()
+	})
+
+	rec := &record{Name: "macos-demo", Disk: disk, PID: process.Process.Pid, VNCDisp: 1}
+	if err := saveRec(vmDir, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("state-dir", stateDir, "")
+	cmd.Flags().Int("vnc", -1, "")
+	cmd.Flags().String("vnc-password", "", "")
+	if err := cmd.Flags().Set("vnc", "2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("vnc-password", "newpass"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewHandler().Start(cmd, []string{"macos-demo"}); err != nil {
+		t.Fatalf("duplicate start must adopt the live qemu: %v", err)
+	}
+	got, err := loadRec(vmDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PID != rec.PID || got.VNCDisp != 1 {
+		t.Fatalf("live record changed: pid=%d vnc=%d, want pid=%d vnc=1", got.PID, got.VNCDisp, rec.PID)
 	}
 }
 

--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,14 +72,8 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	output, err := captureStdout(t, func() error {
-		return NewHandler().Start(cmd, []string{"macos-demo"})
-	})
-	if err != nil {
+	if err := NewHandler().Start(cmd, []string{"macos-demo"}); err != nil {
 		t.Fatalf("duplicate start must adopt the live qemu: %v", err)
-	}
-	if !strings.Contains(output, "supplied VNC settings ignored because live QEMU cannot be retargeted") {
-		t.Fatalf("duplicate start output = %q, want ignored VNC settings warning", output)
 	}
 	got, err := loadRec(vmDir)
 	if err != nil {
@@ -89,29 +82,6 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 	if got.PID != rec.PID || got.VNCDisp != 1 {
 		t.Fatalf("live record changed: pid=%d vnc=%d, want pid=%d vnc=1", got.PID, got.VNCDisp, rec.PID)
 	}
-}
-
-func captureStdout(t *testing.T, fn func() error) (string, error) {
-	t.Helper()
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	original := os.Stdout
-	os.Stdout = writer
-	callErr := fn()
-	os.Stdout = original
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-	output, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := reader.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return string(output), callErr
 }
 
 func TestCloneOpenCoreBase(t *testing.T) {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -51,6 +51,15 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
+			// A recovery request may have started waiting while another lifecycle
+			// operation (notably `vm export`) held the VM lock. Re-check after
+			// acquiring the lock: the export may already have restarted qemu and
+			// its VNC proxy. Launching a second qemu would fail and launch's error
+			// cleanup would tear down the healthy proxy belonging to the first one.
+			if isRunning(r) {
+				fmt.Printf("%s (pid %d, already running)\n", n, r.PID)
+				return nil
+			}
 			r.VNCDisp, r.VNCPass = vnc, vncPass
 			if err := h.launch(cmd, dir, r); err != nil {
 				return err

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -51,13 +51,8 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			// A recovery request may have started waiting while another lifecycle
-			// operation (notably `vm export`) held the VM lock. Re-check after
-			// acquiring the lock: the export may already have restarted qemu.
-			// Launching a second qemu would fail and launch's error cleanup would
-			// tear down the healthy proxy belonging to the first one. If an earlier
-			// failed duplicate start already removed the proxy, repair only that
-			// host-side process while preserving the live guest.
+			// Another lifecycle operation may have restarted qemu while Start waited
+			// for the VM lock. Adopt the live guest and repair only its VNC proxy.
 			if isRunning(r) {
 				if r.Netns != "" && r.VNCDisp >= 0 && !vncProxyRunning(dir) {
 					if err := startVNCProxy(ctx, dir, r.VNCDisp); err != nil {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -51,15 +51,18 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			// Another lifecycle operation may have restarted qemu while Start waited
-			// for the VM lock. Adopt the live guest and repair only its VNC proxy.
+			// An op that held the lock may have restarted qemu; adopt it and only repair a dead VNC proxy.
 			if isRunning(r) {
 				if r.Netns != "" && r.VNCDisp >= 0 && !vncProxyRunning(dir) {
 					if err := startVNCProxy(ctx, dir, r.VNCDisp); err != nil {
 						return fmt.Errorf("repair vnc proxy: %w", err)
 					}
 				}
-				fmt.Printf("%s (pid %d, already running)\n", n, r.PID)
+				if cmd.Flags().Changed("vnc") || cmd.Flags().Changed("vnc-password") {
+					fmt.Printf("%s (pid %d, already running; supplied VNC settings ignored because live QEMU cannot be retargeted)\n", n, r.PID)
+				} else {
+					fmt.Printf("%s (pid %d, already running)\n", n, r.PID)
+				}
 				return nil
 			}
 			r.VNCDisp, r.VNCPass = vnc, vncPass

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -53,10 +53,17 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			}
 			// A recovery request may have started waiting while another lifecycle
 			// operation (notably `vm export`) held the VM lock. Re-check after
-			// acquiring the lock: the export may already have restarted qemu and
-			// its VNC proxy. Launching a second qemu would fail and launch's error
-			// cleanup would tear down the healthy proxy belonging to the first one.
+			// acquiring the lock: the export may already have restarted qemu.
+			// Launching a second qemu would fail and launch's error cleanup would
+			// tear down the healthy proxy belonging to the first one. If an earlier
+			// failed duplicate start already removed the proxy, repair only that
+			// host-side process while preserving the live guest.
 			if isRunning(r) {
+				if r.Netns != "" && r.VNCDisp >= 0 && !vncProxyRunning(dir) {
+					if err := startVNCProxy(ctx, dir, r.VNCDisp); err != nil {
+						return fmt.Errorf("repair vnc proxy: %w", err)
+					}
+				}
 				fmt.Printf("%s (pid %d, already running)\n", n, r.PID)
 				return nil
 			}

--- a/cmd/vm/vnc.go
+++ b/cmd/vm/vnc.go
@@ -96,10 +96,7 @@ func startVNCProxy(ctx context.Context, dir string, disp int) error {
 
 func vncProxyRunning(dir string) bool {
 	pid, err := utils.ReadPIDFile(filepath.Join(dir, vncProxyPID))
-	if err != nil {
-		return false
-	}
-	return utils.VerifyProcessCmdline(pid, filepath.Base(os.Args[0]), filepath.Join(dir, vncSockName))
+	return err == nil && utils.VerifyProcessCmdline(pid, filepath.Base(os.Args[0]), filepath.Join(dir, vncSockName))
 }
 
 // stopVNCProxy kills a running proxy (best-effort). Zero grace: the proxy traps SIGTERM via the root NotifyContext and would keep accepting, and SIGKILL loses nothing on a stateless pipe.

--- a/cmd/vm/vnc.go
+++ b/cmd/vm/vnc.go
@@ -94,11 +94,19 @@ func startVNCProxy(ctx context.Context, dir string, disp int) error {
 	return nil
 }
 
+func vncProxyRunning(dir string) bool {
+	pid, err := utils.ReadPIDFile(filepath.Join(dir, vncProxyPID))
+	if err != nil {
+		return false
+	}
+	return utils.VerifyProcessCmdline(pid, filepath.Base(os.Args[0]), filepath.Join(dir, vncSockName))
+}
+
 // stopVNCProxy kills a running proxy (best-effort). Zero grace: the proxy traps SIGTERM via the root NotifyContext and would keep accepting, and SIGKILL loses nothing on a stateless pipe.
 func stopVNCProxy(ctx context.Context, dir string) {
 	pidPath := filepath.Join(dir, vncProxyPID)
 	if pid, err := utils.ReadPIDFile(pidPath); err == nil {
-		_ = utils.TerminateProcess(ctx, pid, filepath.Base(os.Args[0]), vncProxyOp, 0)
+		_ = utils.TerminateProcess(ctx, pid, filepath.Base(os.Args[0]), filepath.Join(dir, vncSockName), 0)
 	}
 	_ = os.Remove(pidPath)
 }

--- a/cmd/vm/vnc_test.go
+++ b/cmd/vm/vnc_test.go
@@ -2,12 +2,13 @@ package vm
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cocoonstack/cocoon/utils"
 )
 
 func TestRequireCNIVNCPassword(t *testing.T) {
@@ -75,16 +76,14 @@ func TestVNCProxyRunning(t *testing.T) {
 		_ = proxy.Process.Kill()
 		_ = proxy.Wait()
 	})
-	if err := os.WriteFile(filepath.Join(dir, vncProxyPID), []byte(fmt.Sprintf("%d\n", proxy.Process.Pid)), 0o600); err != nil {
+	if err := utils.WritePIDFile(filepath.Join(dir, vncProxyPID), proxy.Process.Pid); err != nil {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !vncProxyRunning(dir) && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !vncProxyRunning(dir) {
-		t.Fatal("matching proxy process reported as stopped")
+	if err := utils.WaitFor(t.Context(), 2*time.Second, 10*time.Millisecond, func() (bool, error) {
+		return vncProxyRunning(dir), nil
+	}); err != nil {
+		t.Fatalf("matching proxy process reported as stopped: %v", err)
 	}
 }
 

--- a/cmd/vm/vnc_test.go
+++ b/cmd/vm/vnc_test.go
@@ -2,7 +2,12 @@ package vm
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestRequireCNIVNCPassword(t *testing.T) {
@@ -52,4 +57,41 @@ func TestValidateVNCPassword(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVNCProxyRunning(t *testing.T) {
+	dir := t.TempDir()
+	if vncProxyRunning(dir) {
+		t.Fatal("missing proxy pidfile reported as running")
+	}
+
+	sock := filepath.Join(dir, vncSockName)
+	proxy := exec.Command(os.Args[0], "-test.run=TestVNCProxyHelperProcess", "--", vncProxyOp, sock)
+	proxy.Env = append(os.Environ(), "COCOON_MACOS_VNC_PROXY_HELPER=1")
+	if err := proxy.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = proxy.Process.Kill()
+		_ = proxy.Wait()
+	})
+	if err := os.WriteFile(filepath.Join(dir, vncProxyPID), []byte(fmt.Sprintf("%d\n", proxy.Process.Pid)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !vncProxyRunning(dir) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !vncProxyRunning(dir) {
+		t.Fatal("matching proxy process reported as stopped")
+	}
+}
+
+func TestVNCProxyHelperProcess(t *testing.T) {
+	if os.Getenv("COCOON_MACOS_VNC_PROXY_HELPER") != "1" {
+		return
+	}
+	time.Sleep(time.Minute)
+	os.Exit(0)
 }


### PR DESCRIPTION
## Problem

Lifecycle operations can overlap: a queued `vm start` may acquire the VM lock after another operation has already restarted QEMU. Launching a second QEMU then fails and can disturb an otherwise healthy guest.

Separately, the host-side VNC proxy may be missing while QEMU and its Unix VNC socket are still healthy, leaving the VM running but unreachable over VNC.

## Fix

- treat `vm start` as idempotent when the recorded QEMU process identity is still valid
- preserve the running VM's current launch state instead of applying start flags to an already-running process
- recreate the VNC proxy when QEMU is healthy but the proxy is missing
- verify the proxy using the executable name and VM-specific Unix socket path

This intentionally does not add compatibility for deployment-specific wrapper process names.

## Validation

- `go test ./...`
