### PR TITLE
fix: make OpenCore NBD injection lifecycle safe

### DIFF
--- a/qemu/inject.go
+++ b/qemu/inject.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -81,7 +83,6 @@ func waitForPart(ctx context.Context, nbd string) error {
 		if _, err := os.Stat(nbd + "p1"); err == nil {
 			return true, nil
 		}
-		_ = exec.CommandContext(ctx, "partprobe", nbd).Run()
 		return false, nil
 	}); err != nil {
 		return fmt.Errorf("wait for partition on %s: %w", nbd, err)
@@ -187,6 +188,13 @@ func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) 
 		if _, err := os.Stat(fmt.Sprintf("/sys/block/nbd%d/pid", i)); !os.IsNotExist(err) {
 			continue
 		}
+		referenced, err := processReferencesBlockDevice("/proc", nbd)
+		if err != nil {
+			return nil, fmt.Errorf("check whether %s is referenced by a process: %w", nbd, err)
+		}
+		if referenced {
+			continue
+		}
 		out, cerr := exec.CommandContext(ctx, "qemu-nbd", qemuNBDConnectArgs(nbd, pidFile, ocPath)...).CombinedOutput()
 		if cerr == nil {
 			pid, err := utils.ReadPIDFile(pidFile)
@@ -211,6 +219,50 @@ func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) 
 		return nil, lastErr
 	}
 	return nil, errors.New("no free /dev/nbd device (is the nbd module loaded)")
+}
+
+// processReferencesBlockDevice catches userspace operations that are still
+// blocked on an NBD device after the kernel has already removed its sysfs pid.
+// Reusing such a device can block the next qemu-nbd attach indefinitely.
+func processReferencesBlockDevice(procRoot, device string) (bool, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", procRoot, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		cmdlinePath := filepath.Join(procRoot, entry.Name(), "cmdline")
+		cmdline, err := os.ReadFile(cmdlinePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("read %s: %w", cmdlinePath, err)
+		}
+		for arg := range strings.SplitSeq(string(cmdline), "\x00") {
+			if nbdArgReferencesDevice(arg, device) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func nbdArgReferencesDevice(arg, device string) bool {
+	if arg == device || arg == "--connect="+device {
+		return true
+	}
+	partition := strings.TrimPrefix(arg, device+"p")
+	if partition == arg || partition == "" {
+		return false
+	}
+	_, err := strconv.Atoi(partition)
+	return err == nil
 }
 
 func qemuNBDConnectArgs(nbd, pidFile, ocPath string) []string {

--- a/qemu/inject.go
+++ b/qemu/inject.go
@@ -33,6 +33,47 @@ type nbdConnection struct {
 	ocPath  string
 }
 
+// fresh context, not the caller's: disconnect must still run when the caller is unwinding after a timeout.
+func (c *nbdConnection) disconnect() error {
+	logger := log.WithFunc("qemu.disconnectNBD")
+	var commandErr error
+	disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), nbdCommandTimeout)
+	if out, err := exec.CommandContext(disconnectCtx, "qemu-nbd", "--disconnect", c.device).CombinedOutput(); err != nil {
+		logger.Warnf(disconnectCtx, "disconnect %s (output: %s): %v", c.device, out, err)
+		commandErr = fmt.Errorf("disconnect %s (output: %s): %w", c.device, out, err)
+	}
+	disconnectCancel()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+	defer waitCancel()
+	if err := utils.WaitFor(waitCtx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
+		held, scanErr := isFileHeld(c.ocPath)
+		return !held, scanErr
+	}); err != nil {
+		logger.Warnf(waitCtx, "qcow2 %s still held after nbd disconnect: %v", c.ocPath, err)
+		killCtx, killCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+		defer killCancel()
+		var cleanupErrs []error
+		if cleanupErr := utils.TerminateProcess(killCtx, c.pid, "qemu-nbd", c.ocPath, time.Second); cleanupErr != nil {
+			logger.Warnf(killCtx, "terminate qemu-nbd pid %d for %s: %v", c.pid, c.ocPath, cleanupErr)
+			cleanupErrs = append(cleanupErrs, cleanupErr)
+		}
+		if cleanupErr := cleanupNBDForPath(killCtx, c.ocPath); cleanupErr != nil {
+			logger.Warnf(killCtx, "terminate stale qemu-nbd for %s: %v", c.ocPath, cleanupErr)
+			cleanupErrs = append(cleanupErrs, cleanupErr)
+		}
+		commandErr = errors.Join(commandErr, err, errors.Join(cleanupErrs...))
+	}
+	_ = os.Remove(c.pidFile)
+	held, err := isFileHeld(c.ocPath)
+	if err != nil {
+		return errors.Join(commandErr, err)
+	}
+	if !held {
+		return nil
+	}
+	return commandErr
+}
+
 // InjectConfig mounts the OpenCore qcow2 via qemu-nbd (the only way to edit a FAT partition inside a qcow2; needs root + the nbd module) and patches config.plist with a per-VM identity.
 func InjectConfig(ctx context.Context, ocPath string, sm *SMBIOS) error {
 	return withNBDLease(ctx, nbdLeasePath, func() (retErr error) {
@@ -65,9 +106,7 @@ func InjectConfig(ctx context.Context, ocPath string, sm *SMBIOS) error {
 	})
 }
 
-// withNBDLease serializes the complete connect/mount/patch/unmount/disconnect
-// transaction across cocoon-macos processes. A free-device check followed by
-// qemu-nbd --connect is not atomic, so choosing devices concurrently is unsafe.
+// serialize the whole transaction: a free-device check then qemu-nbd --connect is not atomic across processes.
 func withNBDLease(ctx context.Context, path string, fn func() error) error {
 	l := flock.New(path)
 	if err := l.Lock(ctx); err != nil {
@@ -108,58 +147,14 @@ func cleanupNBDMount(mnt string, mounted bool) error {
 	return nil
 }
 
-// disconnect waits out qemu-nbd's asynchronous release. Cleanup deliberately
-// uses a fresh context because the caller is commonly unwinding after timeout.
-func (c *nbdConnection) disconnect() error {
-	logger := log.WithFunc("qemu.disconnectNBD")
-	var commandErr error
-	disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), nbdCommandTimeout)
-	if out, err := exec.CommandContext(disconnectCtx, "qemu-nbd", "--disconnect", c.device).CombinedOutput(); err != nil {
-		logger.Warnf(disconnectCtx, "disconnect %s (output: %s): %v", c.device, out, err)
-		commandErr = fmt.Errorf("disconnect %s (output: %s): %w", c.device, out, err)
-	}
-	disconnectCancel()
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
-	defer waitCancel()
-	if err := utils.WaitFor(waitCtx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
-		held, scanErr := isFileHeld(c.ocPath)
-		return !held, scanErr
-	}); err != nil {
-		logger.Warnf(waitCtx, "qcow2 %s still held after nbd disconnect: %v", c.ocPath, err)
-		killCtx, killCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
-		defer killCancel()
-		var cleanupErrs []error
-		if cleanupErr := utils.TerminateProcess(killCtx, c.pid, "qemu-nbd", c.ocPath, time.Second); cleanupErr != nil {
-			logger.Warnf(killCtx, "terminate qemu-nbd pid %d for %s: %v", c.pid, c.ocPath, cleanupErr)
-			cleanupErrs = append(cleanupErrs, cleanupErr)
-		}
-		if cleanupErr := CleanupNBDForPath(killCtx, c.ocPath); cleanupErr != nil {
-			logger.Warnf(killCtx, "terminate stale qemu-nbd for %s: %v", c.ocPath, cleanupErr)
-			cleanupErrs = append(cleanupErrs, cleanupErr)
-		}
-		commandErr = errors.Join(commandErr, err, errors.Join(cleanupErrs...))
-	}
-	_ = os.Remove(c.pidFile)
-	held, err := isFileHeld(c.ocPath)
-	if err != nil {
-		return errors.Join(commandErr, err)
-	}
-	if !held {
-		return nil
-	}
-	return commandErr
-}
-
 // isFileHeld matches the daemonized qemu-nbd server's cmdline — cheaper than scanning fd tables, and that server is the only holder to wait out.
 func isFileHeld(ocPath string) (bool, error) {
 	pids, err := utils.FindVMMByCmdline("qemu-nbd", ocPath)
 	return len(pids) > 0, err
 }
 
-// CleanupNBDForPath terminates qemu-nbd processes whose command line references
-// path. PID identity is verified before signaling, so an unrelated process is
-// never killed even if a PID was reused.
-func CleanupNBDForPath(ctx context.Context, path string) error {
+// cleanupNBDForPath terminates qemu-nbd holders of path; PID identity is verified so a reused PID is never hit.
+func cleanupNBDForPath(ctx context.Context, path string) error {
 	pids, err := utils.FindVMMByCmdline("qemu-nbd", path)
 	if err != nil {
 		return fmt.Errorf("scan qemu-nbd processes for %s: %w", path, err)
@@ -173,9 +168,7 @@ func CleanupNBDForPath(ctx context.Context, path string) error {
 	return errors.Join(errs...)
 }
 
-// connectFreeNBD is called while holding the host-wide NBD lease. --fork is
-// required: without it qemu-nbd remains in the foreground for the lifetime of
-// the mapping and the invoking CLI never reaches the mount/patch steps.
+// holds the nbd lease; --fork or qemu-nbd stays foreground and the caller never reaches mount/patch.
 func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) {
 	var lastErr error
 	pidFile := ocPath + ".nbd.pid"
@@ -203,13 +196,13 @@ func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) 
 			}
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
 			_ = exec.CommandContext(cleanupCtx, "qemu-nbd", "--disconnect", nbd).Run()
-			_ = CleanupNBDForPath(cleanupCtx, ocPath)
+			_ = cleanupNBDForPath(cleanupCtx, ocPath)
 			cancel()
 			return nil, fmt.Errorf("read qemu-nbd pid file %s: %w", pidFile, err)
 		}
 		lastErr = fmt.Errorf("connect qemu-nbd %s (output: %s): %w", nbd, out, cerr)
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
-		_ = CleanupNBDForPath(cleanupCtx, ocPath)
+		_ = cleanupNBDForPath(cleanupCtx, ocPath)
 		cancel()
 		if ctx.Err() != nil {
 			return nil, errors.Join(lastErr, ctx.Err())
@@ -221,9 +214,7 @@ func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) 
 	return nil, errors.New("no free /dev/nbd device (is the nbd module loaded)")
 }
 
-// processReferencesBlockDevice catches userspace operations that are still
-// blocked on an NBD device after the kernel has already removed its sysfs pid.
-// Reusing such a device can block the next qemu-nbd attach indefinitely.
+// a device can stay held by a blocked userspace op after the kernel drops its sysfs pid; reusing it wedges the next attach.
 func processReferencesBlockDevice(procRoot, device string) (bool, error) {
 	entries, err := os.ReadDir(procRoot)
 	if err != nil {

--- a/qemu/inject.go
+++ b/qemu/inject.go
@@ -13,69 +13,173 @@ import (
 	"github.com/projecteru2/core/log"
 	"howett.net/plist"
 
+	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/utils"
 )
 
+const (
+	nbdDeviceCount    = 16
+	nbdLeasePath      = "/run/lock/cocoon-macos-nbd.lock"
+	nbdCleanupTimeout = 15 * time.Second
+	nbdCommandTimeout = 5 * time.Second
+)
+
+type nbdConnection struct {
+	device  string
+	pid     int
+	pidFile string
+	ocPath  string
+}
+
 // InjectConfig mounts the OpenCore qcow2 via qemu-nbd (the only way to edit a FAT partition inside a qcow2; needs root + the nbd module) and patches config.plist with a per-VM identity.
 func InjectConfig(ctx context.Context, ocPath string, sm *SMBIOS) error {
-	_ = exec.CommandContext(ctx, "modprobe", "nbd", "max_part=8").Run()
-	nbd, err := connectFreeNBD(ctx, ocPath)
-	if err != nil {
-		return err
-	}
-	// cleanup stays on plain exec.Command: it must still run after ctx cancellation
-	defer disconnectNBD(ctx, nbd, ocPath)
-	waitForPart(ctx, nbd)
-	mnt, err := os.MkdirTemp("", "oc-efi-")
-	if err != nil {
-		return fmt.Errorf("create mount dir: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(mnt) }()
-	var mountErr error
-	for _, p := range []string{nbd + "p1", nbd + "p2", nbd} {
-		if mountErr = exec.CommandContext(ctx, "mount", p, mnt).Run(); mountErr == nil {
-			break
+	return withNBDLease(ctx, nbdLeasePath, func() (retErr error) {
+		_ = exec.CommandContext(ctx, "modprobe", "nbd", "max_part=8").Run()
+		conn, connectErr := connectFreeNBD(ctx, ocPath)
+		if connectErr != nil {
+			return connectErr
 		}
+		defer func() { retErr = errors.Join(retErr, conn.disconnect()) }()
+		if waitErr := waitForPart(ctx, conn.device); waitErr != nil {
+			return waitErr
+		}
+		mnt, err := os.MkdirTemp("", "oc-efi-")
+		if err != nil {
+			return fmt.Errorf("create mount dir: %w", err)
+		}
+		mounted := false
+		defer func() { retErr = errors.Join(retErr, cleanupNBDMount(mnt, mounted)) }()
+		var mountErr error
+		for _, p := range []string{conn.device + "p1", conn.device + "p2", conn.device} {
+			if mountErr = exec.CommandContext(ctx, "mount", p, mnt).Run(); mountErr == nil {
+				mounted = true
+				break
+			}
+		}
+		if mountErr != nil {
+			return fmt.Errorf("mount OpenCore EFI partition on %s: %w", conn.device, mountErr)
+		}
+		return patchPlist(filepath.Join(mnt, "EFI", "OC", "config.plist"), sm)
+	})
+}
+
+// withNBDLease serializes the complete connect/mount/patch/unmount/disconnect
+// transaction across cocoon-macos processes. A free-device check followed by
+// qemu-nbd --connect is not atomic, so choosing devices concurrently is unsafe.
+func withNBDLease(ctx context.Context, path string, fn func() error) error {
+	l := flock.New(path)
+	if err := l.Lock(ctx); err != nil {
+		return fmt.Errorf("lock qemu-nbd lease: %w", err)
 	}
-	if mountErr != nil {
-		return fmt.Errorf("mount OpenCore EFI partition on %s: %w", nbd, mountErr)
-	}
-	defer func() { _ = exec.Command("umount", mnt).Run() }()
-	return patchPlist(filepath.Join(mnt, "EFI", "OC", "config.plist"), sm)
+	defer func() { _ = l.Unlock(context.Background()) }()
+	return fn()
 }
 
 // waitForPart blocks until the kernel's async partition scan exposes nbdXp1 for the mount.
-func waitForPart(ctx context.Context, nbd string) {
-	_ = utils.WaitFor(ctx, 5*time.Second, 100*time.Millisecond, func() (bool, error) {
+func waitForPart(ctx context.Context, nbd string) error {
+	if err := utils.WaitFor(ctx, 5*time.Second, 100*time.Millisecond, func() (bool, error) {
 		if _, err := os.Stat(nbd + "p1"); err == nil {
 			return true, nil
 		}
 		_ = exec.CommandContext(ctx, "partprobe", nbd).Run()
 		return false, nil
-	})
+	}); err != nil {
+		return fmt.Errorf("wait for partition on %s: %w", nbd, err)
+	}
+	return nil
 }
 
-// disconnectNBD waits out qemu-nbd's asynchronous release, or the qemu launch races in and fails with "Failed to get shared write lock".
-func disconnectNBD(ctx context.Context, nbd, ocPath string) {
-	logger := log.WithFunc("qemu.disconnectNBD")
-	_ = exec.Command("qemu-nbd", "--disconnect", nbd).Run()
-	if err := utils.WaitFor(ctx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
-		return !isFileHeld(ocPath), nil
-	}); err != nil {
-		logger.Warnf(ctx, "qcow2 %s still held after nbd disconnect: %v", ocPath, err)
+func cleanupNBDMount(mnt string, mounted bool) error {
+	if !mounted {
+		if err := os.Remove(mnt); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove mount dir %s: %w", mnt, err)
+		}
+		return nil
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "umount", mnt).CombinedOutput(); err != nil {
+		return fmt.Errorf("unmount %s (output: %s): %w", mnt, out, err)
+	}
+	if err := os.Remove(mnt); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove mount dir %s: %w", mnt, err)
+	}
+	return nil
+}
+
+// disconnect waits out qemu-nbd's asynchronous release. Cleanup deliberately
+// uses a fresh context because the caller is commonly unwinding after timeout.
+func (c *nbdConnection) disconnect() error {
+	logger := log.WithFunc("qemu.disconnectNBD")
+	var commandErr error
+	disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), nbdCommandTimeout)
+	if out, err := exec.CommandContext(disconnectCtx, "qemu-nbd", "--disconnect", c.device).CombinedOutput(); err != nil {
+		logger.Warnf(disconnectCtx, "disconnect %s (output: %s): %v", c.device, out, err)
+		commandErr = fmt.Errorf("disconnect %s (output: %s): %w", c.device, out, err)
+	}
+	disconnectCancel()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+	defer waitCancel()
+	if err := utils.WaitFor(waitCtx, 10*time.Second, 100*time.Millisecond, func() (bool, error) {
+		held, scanErr := isFileHeld(c.ocPath)
+		return !held, scanErr
+	}); err != nil {
+		logger.Warnf(waitCtx, "qcow2 %s still held after nbd disconnect: %v", c.ocPath, err)
+		killCtx, killCancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+		defer killCancel()
+		var cleanupErrs []error
+		if cleanupErr := utils.TerminateProcess(killCtx, c.pid, "qemu-nbd", c.ocPath, time.Second); cleanupErr != nil {
+			logger.Warnf(killCtx, "terminate qemu-nbd pid %d for %s: %v", c.pid, c.ocPath, cleanupErr)
+			cleanupErrs = append(cleanupErrs, cleanupErr)
+		}
+		if cleanupErr := CleanupNBDForPath(killCtx, c.ocPath); cleanupErr != nil {
+			logger.Warnf(killCtx, "terminate stale qemu-nbd for %s: %v", c.ocPath, cleanupErr)
+			cleanupErrs = append(cleanupErrs, cleanupErr)
+		}
+		commandErr = errors.Join(commandErr, err, errors.Join(cleanupErrs...))
+	}
+	_ = os.Remove(c.pidFile)
+	held, err := isFileHeld(c.ocPath)
+	if err != nil {
+		return errors.Join(commandErr, err)
+	}
+	if !held {
+		return nil
+	}
+	return commandErr
 }
 
 // isFileHeld matches the daemonized qemu-nbd server's cmdline — cheaper than scanning fd tables, and that server is the only holder to wait out.
-func isFileHeld(ocPath string) bool {
+func isFileHeld(ocPath string) (bool, error) {
 	pids, err := utils.FindVMMByCmdline("qemu-nbd", ocPath)
-	return err == nil && len(pids) > 0
+	return len(pids) > 0, err
 }
 
-// connectFreeNBD claims a device by connecting: the connect itself is the exclusive operation, so a race with another VM create just advances to the next candidate.
-func connectFreeNBD(ctx context.Context, ocPath string) (string, error) {
+// CleanupNBDForPath terminates qemu-nbd processes whose command line references
+// path. PID identity is verified before signaling, so an unrelated process is
+// never killed even if a PID was reused.
+func CleanupNBDForPath(ctx context.Context, path string) error {
+	pids, err := utils.FindVMMByCmdline("qemu-nbd", path)
+	if err != nil {
+		return fmt.Errorf("scan qemu-nbd processes for %s: %w", path, err)
+	}
+	var errs []error
+	for _, pid := range pids {
+		if err := utils.TerminateProcess(ctx, pid, "qemu-nbd", path, time.Second); err != nil {
+			errs = append(errs, fmt.Errorf("terminate qemu-nbd pid %d: %w", pid, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// connectFreeNBD is called while holding the host-wide NBD lease. --fork is
+// required: without it qemu-nbd remains in the foreground for the lifetime of
+// the mapping and the invoking CLI never reaches the mount/patch steps.
+func connectFreeNBD(ctx context.Context, ocPath string) (*nbdConnection, error) {
 	var lastErr error
-	for i := range 16 {
+	pidFile := ocPath + ".nbd.pid"
+	_ = os.Remove(pidFile)
+	for i := range nbdDeviceCount {
 		nbd := fmt.Sprintf("/dev/nbd%d", i)
 		if _, err := os.Stat(nbd); err != nil {
 			continue
@@ -83,16 +187,34 @@ func connectFreeNBD(ctx context.Context, ocPath string) (string, error) {
 		if _, err := os.Stat(fmt.Sprintf("/sys/block/nbd%d/pid", i)); !os.IsNotExist(err) {
 			continue
 		}
-		out, cerr := exec.CommandContext(ctx, "qemu-nbd", "--connect="+nbd, "-f", "qcow2", ocPath).CombinedOutput()
+		out, cerr := exec.CommandContext(ctx, "qemu-nbd", qemuNBDConnectArgs(nbd, pidFile, ocPath)...).CombinedOutput()
 		if cerr == nil {
-			return nbd, nil
+			pid, err := utils.ReadPIDFile(pidFile)
+			if err == nil {
+				return &nbdConnection{device: nbd, pid: pid, pidFile: pidFile, ocPath: ocPath}, nil
+			}
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+			_ = exec.CommandContext(cleanupCtx, "qemu-nbd", "--disconnect", nbd).Run()
+			_ = CleanupNBDForPath(cleanupCtx, ocPath)
+			cancel()
+			return nil, fmt.Errorf("read qemu-nbd pid file %s: %w", pidFile, err)
 		}
 		lastErr = fmt.Errorf("connect qemu-nbd %s (output: %s): %w", nbd, out, cerr)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), nbdCleanupTimeout)
+		_ = CleanupNBDForPath(cleanupCtx, ocPath)
+		cancel()
+		if ctx.Err() != nil {
+			return nil, errors.Join(lastErr, ctx.Err())
+		}
 	}
 	if lastErr != nil {
-		return "", lastErr
+		return nil, lastErr
 	}
-	return "", errors.New("no free /dev/nbd device (is the nbd module loaded)")
+	return nil, errors.New("no free /dev/nbd device (is the nbd module loaded)")
+}
+
+func qemuNBDConnectArgs(nbd, pidFile, ocPath string) []string {
+	return []string{"--fork", "--pid-file=" + pidFile, "--connect=" + nbd, "-f", "qcow2", ocPath}
 }
 
 func patchPlist(path string, sm *SMBIOS) error {

--- a/qemu/inject_test.go
+++ b/qemu/inject_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -71,6 +72,44 @@ func TestWithNBDLeaseHonorsCancellation(t *testing.T) {
 		t.Fatal("waiting NBD lease ignored context cancellation")
 	}
 	close(release)
+}
+
+func TestProcessReferencesBlockDevice(t *testing.T) {
+	procRoot := t.TempDir()
+	writeCmdline := func(pid, command string, args ...string) {
+		t.Helper()
+		dir := filepath.Join(procRoot, pid)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		argv := append([]string{command}, args...)
+		data := append([]byte(strings.Join(argv, "\x00")), 0)
+		if err := os.WriteFile(filepath.Join(dir, "cmdline"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeCmdline("101", "partprobe", "/dev/nbd0")
+	writeCmdline("102", "mount", "/dev/nbd1p1", "/mnt")
+	writeCmdline("103", "qemu-nbd", "--connect=/dev/nbd2", "disk.qcow2")
+	writeCmdline("104", "helper", "/dev/nbd01")
+
+	for _, device := range []string{"/dev/nbd0", "/dev/nbd1", "/dev/nbd2"} {
+		busy, err := processReferencesBlockDevice(procRoot, device)
+		if err != nil {
+			t.Fatalf("processReferencesBlockDevice(%s): %v", device, err)
+		}
+		if !busy {
+			t.Errorf("processReferencesBlockDevice(%s) = false, want true", device)
+		}
+	}
+	busy, err := processReferencesBlockDevice(procRoot, "/dev/nbd3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if busy {
+		t.Error("unreferenced /dev/nbd3 reported busy")
+	}
 }
 
 // sampleConfig mirrors OSX-KVM's config.plist so patchPlist round-trips a realistic input.

--- a/qemu/inject_test.go
+++ b/qemu/inject_test.go
@@ -15,6 +15,45 @@ import (
 	"howett.net/plist"
 )
 
+// sampleConfig mirrors OSX-KVM's config.plist so patchPlist round-trips a realistic input.
+const sampleConfig = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Misc</key>
+	<dict>
+		<key>Security</key>
+		<dict>
+			<key>Vault</key>
+			<string>Optional</string>
+		</dict>
+	</dict>
+	<key>PlatformInfo</key>
+	<dict>
+		<key>Automatic</key>
+		<true/>
+		<key>UpdateSMBIOSMode</key>
+		<string>Create</string>
+		<key>Generic</key>
+		<dict>
+			<key>SystemProductName</key>
+			<string>iMac19,1</string>
+			<key>SystemSerialNumber</key>
+			<string>W00000000001</string>
+			<key>MLB</key>
+			<string>M0000000000000001</string>
+			<key>SystemUUID</key>
+			<string>00000000-0000-0000-0000-000000000000</string>
+			<key>ROM</key>
+			<data>ESIzRFVm</data>
+			<key>SpoofVendor</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>
+`
+
 func TestQemuNBDConnectArgsForkAndTrackServer(t *testing.T) {
 	want := []string{"--fork", "--pid-file=/state/vm/OpenCore.qcow2.nbd.pid", "--connect=/dev/nbd3", "-f", "qcow2", "/state/vm/OpenCore.qcow2"}
 	if got := qemuNBDConnectArgs("/dev/nbd3", "/state/vm/OpenCore.qcow2.nbd.pid", "/state/vm/OpenCore.qcow2"); !slices.Equal(got, want) {
@@ -111,45 +150,6 @@ func TestProcessReferencesBlockDevice(t *testing.T) {
 		t.Error("unreferenced /dev/nbd3 reported busy")
 	}
 }
-
-// sampleConfig mirrors OSX-KVM's config.plist so patchPlist round-trips a realistic input.
-const sampleConfig = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>Misc</key>
-	<dict>
-		<key>Security</key>
-		<dict>
-			<key>Vault</key>
-			<string>Optional</string>
-		</dict>
-	</dict>
-	<key>PlatformInfo</key>
-	<dict>
-		<key>Automatic</key>
-		<true/>
-		<key>UpdateSMBIOSMode</key>
-		<string>Create</string>
-		<key>Generic</key>
-		<dict>
-			<key>SystemProductName</key>
-			<string>iMac19,1</string>
-			<key>SystemSerialNumber</key>
-			<string>W00000000001</string>
-			<key>MLB</key>
-			<string>M0000000000000001</string>
-			<key>SystemUUID</key>
-			<string>00000000-0000-0000-0000-000000000000</string>
-			<key>ROM</key>
-			<data>ESIzRFVm</data>
-			<key>SpoofVendor</key>
-			<true/>
-		</dict>
-	</dict>
-</dict>
-</plist>
-`
 
 func TestPatchPlist(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "config.plist")

--- a/qemu/inject_test.go
+++ b/qemu/inject_test.go
@@ -1,13 +1,77 @@
 package qemu
 
 import (
+	"context"
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"howett.net/plist"
 )
+
+func TestQemuNBDConnectArgsForkAndTrackServer(t *testing.T) {
+	want := []string{"--fork", "--pid-file=/state/vm/OpenCore.qcow2.nbd.pid", "--connect=/dev/nbd3", "-f", "qcow2", "/state/vm/OpenCore.qcow2"}
+	if got := qemuNBDConnectArgs("/dev/nbd3", "/state/vm/OpenCore.qcow2.nbd.pid", "/state/vm/OpenCore.qcow2"); !slices.Equal(got, want) {
+		t.Fatalf("qemu-nbd args = %v, want %v", got, want)
+	}
+}
+
+func TestWithNBDLeaseSerializesConcurrentInjectors(t *testing.T) {
+	const workers = 50
+	lockPath := filepath.Join(t.TempDir(), "nbd.lock")
+	var active, maxActive atomic.Int32
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- withNBDLease(t.Context(), lockPath, func() error {
+				n := active.Add(1)
+				defer active.Add(-1)
+				for old := maxActive.Load(); n > old && !maxActive.CompareAndSwap(old, n); old = maxActive.Load() {
+				}
+				time.Sleep(time.Millisecond)
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("maximum concurrent NBD transactions = %d, want 1", got)
+	}
+}
+
+func TestWithNBDLeaseHonorsCancellation(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "nbd.lock")
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = withNBDLease(t.Context(), lockPath, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	if err := withNBDLease(ctx, lockPath, func() error { return nil }); err == nil {
+		t.Fatal("waiting NBD lease ignored context cancellation")
+	}
+	close(release)
+}
 
 // sampleConfig mirrors OSX-KVM's config.plist so patchPlist round-trips a realistic input.
 const sampleConfig = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

This change makes the OpenCore qcow2 injection flow safe under concurrent VM creation, request cancellation, and stale host NBD state.

The issue is not specific to a particular machine. It can affect any Linux host running concurrent `cocoon-macos` VM creation through `qemu-nbd`.

## Background

Before starting a macOS VM, `cocoon-macos` creates an OpenCore qcow2 overlay and temporarily exposes it as a Linux block device:

```text
OpenCore.qcow2
  -> qemu-nbd
  -> /dev/nbdN
  -> wait for EFI partition
  -> mount
  -> patch config.plist and SMBIOS
  -> unmount
  -> disconnect NBD
```

Each VM requires a unique SMBIOS identity, so this operation is part of the normal VM creation path.

## Root Cause

### 1. `qemu-nbd` was started in foreground mode

The previous command did not use `--fork`:

```bash
qemu-nbd --connect=/dev/nbdN OpenCore.qcow2
```

After establishing the mapping, `qemu-nbd` remained in the foreground. The caller could remain blocked and never reach the mount, patch, unmount, or disconnect steps.

When the request later timed out or was cancelled, cleanup could be skipped or interrupted, leaving processes, NBD mappings, and incomplete VM directories behind.

### 2. NBD selection had a TOCTOU race

The old flow checked whether an NBD device was free and connected it in separate operations:

```text
check /dev/nbdN
  -> device appears free
  -> connect qemu-nbd
```

Two concurrent VM creation requests could observe the same device as free before either request completed the connection.

Because `/dev/nbdN` is a host-global resource, this allowed multiple requests to compete for the same block device.

### 3. Cleanup reused a cancelled request context

Creation and cleanup shared the same request context.

If the create request timed out, cleanup commands such as unmount and disconnect inherited an already-cancelled context and could exit immediately without releasing resources.

This is equivalent to trying to roll back a transaction using an already-expired request context.

### 4. A wedged NBD device could appear free

A previous failed operation could leave a command such as:

```text
partprobe /dev/nbd0
```

blocked in Linux `D` state while waiting for an uninterruptible kernel I/O operation.

In this condition, `/sys/block/nbd0/pid` may already be absent even though a userspace process still references `/dev/nbd0`.

Checking only the sysfs PID could therefore incorrectly classify the device as free. Reusing that device could block the next VM creation flow.

### 5. Repeated `partprobe` calls amplified the problem

The old partition wait loop repeatedly executed `partprobe`.

When the NBD device was already unhealthy, this could create more blocked `partprobe` processes instead of recovering the device.

## Solution

### Run `qemu-nbd` as a tracked background process

The connection now uses:

```bash
qemu-nbd \
  --fork \
  --pid-file=<OpenCore.qcow2.nbd.pid> \
  --connect=/dev/nbdN \
  -f qcow2 \
  <OpenCore.qcow2>
```

`--fork` allows the VM creation flow to continue after the mapping is established.

`--pid-file` records the exact daemon PID so cleanup can target the correct process without relying only on broad process matching.

### Serialize the complete NBD transaction

A host-wide `flock` protects the complete OpenCore injection transaction:

```text
acquire host-wide NBD lock
  -> select a healthy NBD device
  -> connect qcow2
  -> wait for the partition
  -> mount
  -> patch config.plist
  -> unmount
  -> disconnect NBD
release host-wide NBD lock
```

This removes the check-to-use race and prevents concurrent requests from observing or modifying an intermediate NBD state.

The lock is host-wide because all `/dev/nbdN` devices are shared host resources.

Only the short OpenCore injection transaction is serialized. VM boot and normal VM execution remain concurrent.

### Use an independent cleanup context

Unmount, disconnect, process termination, and cleanup polling now use a fresh background context with explicit timeouts.

Cleanup can therefore continue even when the original create request has timed out or been cancelled.

### Verify kernel and userspace state

Before selecting `/dev/nbdN`, the implementation now checks:

1. Whether the device exists.
2. Whether `/sys/block/nbdN/pid` indicates an active mapping.
3. Whether any process in `/proc/*/cmdline` still references:
   - `/dev/nbdN`
   - `/dev/nbdNp1` or another partition
   - `--connect=/dev/nbdN`

If a process still references the device, the device is treated as busy and skipped.

This protects new VM creation requests from stale `partprobe`, mount, or `qemu-nbd` processes whose state is no longer fully represented by sysfs.

### Remove repeated `partprobe` execution

The partition wait loop now waits for the kernel-created partition node instead of repeatedly starting `partprobe`.

This avoids creating additional uninterruptible processes when a device is unhealthy.

### Perform precise cleanup

Cleanup now:

- disconnects the selected NBD device;
- waits for the qcow2 file to no longer be held;
- verifies PID identity before terminating the recorded process;
- only searches for `qemu-nbd` processes referencing the exact qcow2 path;
- removes the PID file after cleanup;
- uses independent timeouts even when the create request was cancelled.

This avoids terminating unrelated processes if a PID has been reused.

## Why This Is a General Fix

This change does not contain any host name, node IP, machine identifier, or special handling for `/dev/nbd0`.

It applies to every configured `/dev/nbdN` device and to any Linux host using the `cocoon-macos` OpenCore injection flow.

A host containing historical blocked processes helped reproduce the issue, but the underlying defects were generic:

- incorrect external process lifecycle management;
- host-global resource contention;
- a TOCTOU race during device selection;
- cancellation interrupting rollback;
- incomplete block-device health detection;
- unsafe reuse of stale devices.

The same design principles can be applied to other `qemu-nbd` users, although the implementation in this MR is scoped to the `cocoon-macos` OpenCore injection path.

## Compatibility

- No public API changes.
- No CLI parameter changes.
- No VM record format changes.
- No image format changes.
- Healthy NBD devices continue to work as before.
- Devices referenced by stale userspace processes are skipped.
- If all NBD devices are unavailable, creation fails explicitly instead of blocking indefinitely.
- VM boot and execution concurrency are not reduced.

## Validation

The following checks passed:

```bash
go test -race ./...
make fmt-check vet lint
```

The tests cover:

- use of `qemu-nbd --fork`;
- creation and use of the PID file;
- 50 concurrent callers competing for the host-wide NBD lease;
- cancellation while waiting for the lease;
- detection of `/dev/nbdN` references;
- detection of partition references such as `/dev/nbdNp1`;
- detection of `--connect=/dev/nbdN`;
- avoidance of false matches such as `/dev/nbd01`.

The fix was also validated in an integration cluster:

- a single-instance batch completed successfully;
- a 10-instance batch completed successfully;
- 50- and 100-instance batches completed the infrastructure-level VM creation path;
- no new blocked `partprobe` process was created;
- no `qemu-nbd` process remained after instance release;
- no failed VM directory remained after cleanup;
- all created instances were released successfully.

Some large-batch application-level readiness samples were delayed by guest control-server or guest IP readiness. These delays occurred after the NBD injection and QEMU launch stages and are independent of the NBD lifecycle issue fixed by this MR.

## Operational Note

Processes already blocked in Linux `D` state generally cannot be removed with `SIGKILL`.

This fix prevents new requests from reusing affected devices and prevents new leaks. Existing historical `D`-state processes may still require a controlled host reboot.

After controlled rolling reboots, the integration hosts were verified with:

```text
qemu-nbd processes: 0
partprobe processes: 0
failed VM directories: 0
```