### PR TITLE
feat: support resizable macOS system disks

### DIFF
--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -45,11 +46,23 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	storage := srcRec.Storage
+	if cmd.Flags().Changed("storage") {
+		storage, err = storageFromFlag(cmd)
+		if err != nil {
+			return err
+		}
+	}
 	dir, overlay, ovmfVars, digest, err := scaffoldVM(cmd, name, srcRec.Image, srcRec.OVMFVars, filepath.Base(srcRec.OVMFVars))
 	if err != nil {
 		return err
 	}
 	ctx := cliutil.CommandContext(cmd)
+	storage, err = resizeSystemDisk(ctx, overlay, storage)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return err
+	}
 	copied, err := copyDataDisks(dir, srcRec.DataDisks)
 	if err != nil {
 		return err
@@ -60,7 +73,7 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	}
 	r := &record{
 		Name: name, Image: srcRec.Image, ImageDigest: digest, Disk: overlay,
-		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: cpus, Memory: srcRec.Memory,
+		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: cpus, Memory: srcRec.Memory, Storage: storage,
 		DataDisks: append(copied, newDisks...),
 		VMID:      utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
 	}

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -123,6 +123,7 @@ func addVMFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("name", "n", "", "VM name (default: generated)")
 	cmd.Flags().Int("cpus", 4, "vCPU count")
 	cmd.Flags().String("memory", "8192", "guest memory in MiB")
+	cmd.Flags().String("storage", "", "system disk size (for example 100Gi); omit to keep the image virtual size, shrinking is rejected")
 	cmd.Flags().Bool("hugepages", false, "back guest RAM with 2 MiB hugepages (needs host hugepages reserved; lower TLB/EPT overhead)")
 	cmd.Flags().Bool("exit-on-reboot", false, "exit QEMU on guest reboot so an external supervisor can relaunch it cold")
 	cmd.Flags().StringArray("data-disk", nil, "attach an extra qcow2 data disk: comma-separated key=value (size= required e.g. size=20G; name= optional, default dataN). Repeatable, max 4. macOS has no in-guest agent, so fstype=/mount= are unsupported — format it in the guest (Disk Utility/diskutil)")

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -126,7 +126,7 @@ func addVMFlags(cmd *cobra.Command) {
 	cmd.Flags().String("storage", "", "system disk size (for example 100Gi); omit to keep the image virtual size, shrinking is rejected")
 	cmd.Flags().Bool("hugepages", false, "back guest RAM with 2 MiB hugepages (needs host hugepages reserved; lower TLB/EPT overhead)")
 	cmd.Flags().Bool("exit-on-reboot", false, "exit QEMU on guest reboot so an external supervisor can relaunch it cold")
-	cmd.Flags().StringArray("data-disk", nil, "attach an extra qcow2 data disk: comma-separated key=value (size= required e.g. size=20G; name= optional, default dataN). Repeatable, max 4. macOS has no in-guest agent, so fstype=/mount= are unsupported — format it in the guest (Disk Utility/diskutil)")
+	cmd.Flags().StringArray("data-disk", nil, "attach an extra qcow2 data disk: comma-separated key=value (size= required e.g. size=20Gi; name= optional, default dataN). Repeatable, max 4. macOS has no in-guest agent, so fstype=/mount= are unsupported — format it in the guest (Disk Utility/diskutil)")
 	cmd.Flags().Int("vnc", -1, "VNC display number for the initial boot (n => port 590n); <0 disables. Launch-scoped: cleared on stop, re-enable per start with `vm start --vnc`")
 	cmd.Flags().Int("ssh-port", 0, "host port forwarded to guest :22; 0 disables")
 	cmd.Flags().String("opencore", "", "OpenCore.qcow2 boot loader (default: <state-dir>/firmware/OpenCore.qcow2; provisioned by scripts/doctor.sh)")

--- a/cmd/vm/datadisk.go
+++ b/cmd/vm/datadisk.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/go-units"
-
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -78,7 +76,7 @@ func parseDataDiskSpec(s string) (types.DataDiskSpec, error) {
 		key, val := strings.TrimSpace(rawKey), strings.TrimSpace(rawVal)
 		switch key {
 		case "size":
-			n, err := units.RAMInBytes(val)
+			n, err := parseSize(val)
 			if err != nil {
 				return spec, fmt.Errorf("data disk: invalid size %q: %w", val, err)
 			}

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -34,6 +34,7 @@ type record struct {
 
 	CPUs         int      `json:"cpus"`
 	Memory       string   `json:"memory"`
+	Storage      int64    `json:"storage"` // system-disk virtual size in bytes
 	VNCDisp      int      `json:"vnc"`
 	VNCPass      string   `json:"-"` // launch-scoped, set from the flag each start; never persisted (would leak at rest)
 	SSHPort      int      `json:"ssh_port"`

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -34,7 +34,7 @@ type record struct {
 
 	CPUs         int      `json:"cpus"`
 	Memory       string   `json:"memory"`
-	Storage      int64    `json:"storage"` // system-disk virtual size in bytes
+	Storage      int64    `json:"storage,omitempty"` // system-disk virtual size in bytes
 	VNCDisp      int      `json:"vnc"`
 	VNCPass      string   `json:"-"` // launch-scoped, set from the flag each start; never persisted (would leak at rest)
 	SSHPort      int      `json:"ssh_port"`

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -150,6 +150,10 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if err = requireCNIVNCPassword(netMode == netCNI, vnc, vncPass); err != nil {
 		return nil, err
 	}
+	storage, err := storageFromFlag(cmd)
+	if err != nil {
+		return nil, err
+	}
 	oc, code, varsTmpl, err := resolveFirmware(cmd)
 	if err != nil {
 		return nil, err
@@ -159,6 +163,11 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 		return nil, err
 	}
 	ctx := cliutil.CommandContext(cmd)
+	storage, err = resizeSystemDisk(ctx, overlay, storage)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
 	mem, _ := cmd.Flags().GetString("memory")
 	ssh, _ := cmd.Flags().GetInt("ssh-port")
 	tap, _ := cmd.Flags().GetString("tap")
@@ -166,7 +175,7 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	exitOnReboot, _ := cmd.Flags().GetBool("exit-on-reboot")
 	r := &record{
 		Name: name, Image: image, ImageDigest: digest, Disk: overlay, OVMFCode: code, OVMFVars: ovmfVars,
-		CPUs: cpus, Memory: mem, VNCDisp: vnc, SSHPort: ssh, VNCPass: vncPass, NetMode: netMode, Tap: tap, Hugepages: huge,
+		CPUs: cpus, Memory: mem, Storage: storage, VNCDisp: vnc, SSHPort: ssh, VNCPass: vncPass, NetMode: netMode, Tap: tap, Hugepages: huge,
 		ExitOnReboot: exitOnReboot,
 		VMID:         utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
 	}

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-macos/home"
@@ -53,6 +54,48 @@ func bakeOverlay(ctx context.Context, base, dst string) error {
 		return fmt.Errorf("bake overlay on %s: %w", base, err)
 	}
 	return nil
+}
+
+func storageFromFlag(cmd *cobra.Command) (int64, error) {
+	raw, _ := cmd.Flags().GetString("storage")
+	if strings.TrimSpace(raw) == "" {
+		return 0, nil
+	}
+	parsed := strings.TrimSpace(raw)
+	if strings.HasSuffix(strings.ToLower(parsed), "i") {
+		parsed = parsed[:len(parsed)-1]
+	}
+	n, err := units.RAMInBytes(parsed)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --storage %q: %w", raw, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("invalid --storage %q: size must be positive", raw)
+	}
+	return n, nil
+}
+
+// resizeSystemDisk expands a newly-created overlay to target bytes. A zero
+// target preserves the image size; shrinking is rejected because qemu-img
+// cannot prove that the guest partition/filesystem would remain intact.
+func resizeSystemDisk(ctx context.Context, path string, target int64) (int64, error) {
+	hdr, ok, err := utils.ReadQcow2Header(path)
+	if err != nil {
+		return 0, fmt.Errorf("read system disk %s: %w", path, err)
+	}
+	if !ok {
+		return 0, fmt.Errorf("system disk %s is not qcow2", path)
+	}
+	if target == 0 || target == hdr.VirtualSize {
+		return hdr.VirtualSize, nil
+	}
+	if target < hdr.VirtualSize {
+		return 0, fmt.Errorf("--storage %d bytes is smaller than image virtual size %d bytes; shrinking is not supported", target, hdr.VirtualSize)
+	}
+	if err := utils.RunQemuImg(ctx, "resize", path, fmt.Sprintf("%d", target)); err != nil {
+		return 0, fmt.Errorf("resize system disk %s to %d bytes: %w", path, target, err)
+	}
+	return target, nil
 }
 
 // scaffoldVM lays down a new VM dir, disk overlay, and OVMF_VARS copy; it refuses an existing record — a second create/clone under the same name would truncate the live overlay.

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -61,23 +61,30 @@ func storageFromFlag(cmd *cobra.Command) (int64, error) {
 	if strings.TrimSpace(raw) == "" {
 		return 0, nil
 	}
-	parsed := strings.TrimSpace(raw)
-	if strings.HasSuffix(strings.ToLower(parsed), "i") {
-		parsed = parsed[:len(parsed)-1]
-	}
-	n, err := units.RAMInBytes(parsed)
+	n, err := parseSize(raw)
 	if err != nil {
 		return 0, fmt.Errorf("invalid --storage %q: %w", raw, err)
-	}
-	if n <= 0 {
-		return 0, fmt.Errorf("invalid --storage %q: size must be positive", raw)
 	}
 	return n, nil
 }
 
-// resizeSystemDisk expands a newly-created overlay to target bytes. A zero
-// target preserves the image size; shrinking is rejected because qemu-img
-// cannot prove that the guest partition/filesystem would remain intact.
+// parseSize accepts Docker and Kubernetes quantity spellings such as 20G, 20Gi and 20GiB.
+func parseSize(raw string) (int64, error) {
+	parsed := strings.TrimSpace(raw)
+	if strings.HasSuffix(strings.ToLower(parsed), "i") {
+		parsed += "B"
+	}
+	n, err := units.RAMInBytes(parsed)
+	if err != nil {
+		return 0, err
+	}
+	if n <= 0 {
+		return 0, errors.New("size must be positive")
+	}
+	return n, nil
+}
+
+// resizeSystemDisk grows a new overlay to target bytes (0 = keep image size); shrinking is rejected because qemu-img cannot prove the guest filesystem survives.
 func resizeSystemDisk(ctx context.Context, path string, target int64) (int64, error) {
 	hdr, ok, err := utils.ReadQcow2Header(path)
 	if err != nil {

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -15,7 +15,9 @@ func TestStorageFromFlag(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "unset keeps image size"},
+		{name: "docker gigabytes", value: "100G", want: 100 << 30},
 		{name: "kubernetes gibibytes", value: "100Gi", want: 100 << 30},
+		{name: "explicit gibibytes", value: "100GiB", want: 100 << 30},
 		{name: "surrounding whitespace", value: " 100Gi ", want: 100 << 30},
 		{name: "plain bytes", value: "107374182400", want: 100 << 30},
 		{name: "zero rejected", value: "0", wantErr: true},

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -7,6 +7,40 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestStorageFromFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    int64
+		wantErr bool
+	}{
+		{name: "unset keeps image size"},
+		{name: "kubernetes gibibytes", value: "100Gi", want: 100 << 30},
+		{name: "surrounding whitespace", value: " 100Gi ", want: 100 << 30},
+		{name: "plain bytes", value: "107374182400", want: 100 << 30},
+		{name: "zero rejected", value: "0", wantErr: true},
+		{name: "invalid rejected", value: "large", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("storage", "", "")
+			if tt.value != "" {
+				if err := cmd.Flags().Set("storage", tt.value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := storageFromFlag(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("storageFromFlag() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("storageFromFlag() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGraceFromFlags(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,7 +20,7 @@ See [Images](images.md) for the store layout and the parallel-Range download.
 # clone the golden image into a per-VM overlay and boot it (x86 Linux + /dev/kvm).
 # IMAGE is a store ref or a direct qcow2 path; firmware defaults to the doctor's install.
 cocoon-macos vm run ghcr.io/cocoonstack/cocoon-macos/tahoe:26 \
-  --name m1 --cpus 4 --memory 8192 --ssh-port 2222 --vnc 1 --random-smbios
+  --name m1 --cpus 4 --memory 8192 --storage 100Gi --ssh-port 2222 --vnc 1 --random-smbios
 
 cocoon-macos vm list           # table (NAME STATE CPU MEM NET VNC SSH IMAGE CREATED); -o json for JSON
 cocoon-macos vm inspect m1     # full record as JSON
@@ -33,6 +33,8 @@ cocoon-macos vm rm m1
   boot; `start` boots a created/stopped VM.
 - `run` is atomic: if the boot fails it removes everything it just created (no half-made VM left
   behind).
+- `--storage` expands the new VM's qcow2 system disk before boot. It accepts values such as `100Gi`
+  or a byte count, never shrinks an image, and is inherited by `clone` unless explicitly overridden.
 
 Networking (`--net`) and VNC (`--vnc` / `--vnc-password`) are covered in
 [Networking & VNC](networking.md); snapshot/clone and `--data-disk` in

--- a/scripts/provision-macos.sh
+++ b/scripts/provision-macos.sh
@@ -309,11 +309,11 @@ echo "$final"
 echo "expanded root APFS container on $physical_store"
 SH
 chmod 755 "$VOL/usr/local/sbin/cocoon-resize-system-disk"
-cat > "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist" <<'PLIST'
+cat > "$VOL/Library/LaunchDaemons/com.cocoon.resize-system-disk.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
-  <key>Label</key><string>io.cocoon.resize-system-disk</string>
+  <key>Label</key><string>com.cocoon.resize-system-disk</string>
   <key>ProgramArguments</key><array><string>/usr/local/sbin/cocoon-resize-system-disk</string></array>
   <key>RunAtLoad</key><true/>
   <key>ProcessType</key><string>Background</string>
@@ -321,7 +321,7 @@ cat > "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist" <<'PLIST'
   <key>StandardErrorPath</key><string>/var/log/cocoon-resize-system-disk.launchd.log</string>
 </dict></plist>
 PLIST
-chown 0:0 "$VOL/usr/local/sbin/cocoon-resize-system-disk" "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist"
-chmod 644 "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist"
+chown 0:0 "$VOL/usr/local/sbin/cocoon-resize-system-disk" "$VOL/Library/LaunchDaemons/com.cocoon.resize-system-disk.plist"
+chmod 644 "$VOL/Library/LaunchDaemons/com.cocoon.resize-system-disk.plist"
 echo "OK installed persistent APFS auto-grow daemon"
 echo "=== PROVISION DONE (user=$USER_NAME, SSH on first boot) ==="

--- a/scripts/provision-macos.sh
+++ b/scripts/provision-macos.sh
@@ -5,6 +5,7 @@
 #   - create a local admin user offline (dscl -f on the volume's dslocal)
 #   - drop a first-boot LaunchDaemon that enables Remote Login (SSH), then self-removes
 #   - install a persistent LaunchDaemon that assigns a per-VM hostname
+#   - install a persistent LaunchDaemon that grows APFS after qcow2 expansion
 # Diagnostics are printed so a VNC screenshot shows progress/errors.
 set -x
 USER_NAME="${USER_NAME:-cocoon}"
@@ -249,4 +250,78 @@ PLIST
 chown 0:0 "$VOL/Library/LaunchDaemons/com.cocoon.set-hostname.plist" "$VOL/usr/local/sbin/cocoon-set-hostname"
 chmod 644 "$VOL/Library/LaunchDaemons/com.cocoon.set-hostname.plist"
 ls -la "$VOL/Library/LaunchDaemons/com.cocoon.set-hostname.plist"
+
+# Persistent system-disk growth. qemu-img enlarges the virtual disk before
+# boot, but macOS leaves the GPT partition and APFS container at the image's
+# original size. The daemon is idempotent and exits quickly when no growth is
+# available.
+mkdir -p "$VOL/usr/local/sbin"
+cat > "$VOL/usr/local/sbin/cocoon-resize-system-disk" <<'SH'
+#!/bin/zsh
+
+set -eu
+
+log=/var/log/cocoon-resize-system-disk.log
+exec >>"$log" 2>&1
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) resize check started"
+
+physical_store=""
+for _ in {1..12}; do
+  physical_store=$(/usr/sbin/diskutil info / | /usr/bin/awk -F: '/APFS Physical Store/ {gsub(/[[:space:]]/, "", $2); print $2; exit}')
+  [[ -n "$physical_store" ]] && break
+  /bin/sleep 5
+done
+
+if [[ -z "$physical_store" ]]; then
+  echo "unable to determine the root APFS physical store"
+  exit 1
+fi
+
+whole_disk=$(/usr/sbin/diskutil info "$physical_store" | /usr/bin/awk -F: '/Part of Whole/ {gsub(/[[:space:]]/, "", $2); print $2; exit}')
+if [[ -z "$whole_disk" ]]; then
+  echo "unable to determine the whole disk for $physical_store"
+  exit 1
+fi
+
+limits=$(/usr/sbin/diskutil apfs resizeContainer "$physical_store" limits)
+current=$(printf '%s\n' "$limits" | /usr/bin/sed -n 's/.*Current Container size:.*(\([0-9][0-9]*\) Bytes).*/\1/p')
+maximum=$(printf '%s\n' "$limits" | /usr/bin/sed -n 's/.*Maximum.*(\([0-9][0-9]*\) Bytes).*/\1/p')
+if [[ -z "$current" || -z "$maximum" ]]; then
+  echo "unable to parse APFS resize limits for $physical_store"
+  printf '%s\n' "$limits"
+  exit 1
+fi
+
+if (( maximum <= current + 4194304 )); then
+  echo "no expansion needed: current=$current maximum=$maximum"
+  exit 0
+fi
+
+# Refresh the live partition map before growing the APFS container into the
+# free space added by qemu-img resize.
+/usr/bin/printf 'y\n' | /usr/sbin/diskutil repairDisk "$whole_disk"
+/usr/sbin/diskutil apfs resizeContainer "$physical_store" 0
+/bin/sync
+
+final=$(/usr/sbin/diskutil apfs resizeContainer "$physical_store" limits)
+echo "$final"
+echo "expanded root APFS container on $physical_store"
+SH
+chmod 755 "$VOL/usr/local/sbin/cocoon-resize-system-disk"
+cat > "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>io.cocoon.resize-system-disk</string>
+  <key>ProgramArguments</key><array><string>/usr/local/sbin/cocoon-resize-system-disk</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/var/log/cocoon-resize-system-disk.launchd.log</string>
+  <key>StandardErrorPath</key><string>/var/log/cocoon-resize-system-disk.launchd.log</string>
+</dict></plist>
+PLIST
+chown 0:0 "$VOL/usr/local/sbin/cocoon-resize-system-disk" "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist"
+chmod 644 "$VOL/Library/LaunchDaemons/io.cocoon.resize-system-disk.plist"
+echo "OK installed persistent APFS auto-grow daemon"
 echo "=== PROVISION DONE (user=$USER_NAME, SSH on first boot) ==="


### PR DESCRIPTION
## What changed

- add `--storage` to macOS VM create/run/clone
- grow a newly created qcow2 overlay before boot and reject unsafe shrinking
- persist the resulting virtual disk size in the VM record
- install an idempotent first-boot LaunchDaemon that expands the root APFS container into newly available space

## Why

Cloud images currently impose their original virtual disk size on every VM. Supporting safe growth makes one image reusable across multiple storage specifications without rebuilding the image.

## Semantics

- omitted storage keeps the image virtual size
- clone inherits the source size unless explicitly overridden
- requested size may grow but never shrink the image

## Validation

- `GOWORK=off go test ./...`
- `make fmt-check vet lint`
- `bash -n scripts/provision-macos.sh`

