### PR TITLE
fix: make macOS VM creation transactional

### DIFF
--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,21 +20,24 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	name, _ := cmd.Flags().GetString("name")
-	if name == "" {
-		name = src + "-clone-" + time.Now().Format("150405")
-	}
+	name := requestedVMName(cmd, src+"-clone-"+time.Now().Format("150405"))
+	return withVMLock(cliutil.CommandContext(cmd), home.VMDir(cmd, name), func() error {
+		return h.clone(cmd, srcRec, name)
+	})
+}
+
+func (h *Handler) clone(cmd *cobra.Command, srcRec *record, name string) (retErr error) {
 	netMode, _ := cmd.Flags().GetString("net")
 	vnc, _ := cmd.Flags().GetInt("vnc")
 	vncPass, _ := cmd.Flags().GetString("vnc-password")
-	if err = requireCNIVNCPassword(netMode == netCNI, vnc, vncPass); err != nil {
+	if err := requireCNIVNCPassword(netMode == netCNI, vnc, vncPass); err != nil {
 		return err
 	}
 	cpus := srcRec.CPUs
 	if cmd.Flags().Changed("cpus") {
 		cpus, _ = cmd.Flags().GetInt("cpus")
 	}
-	if err = validateMacOSCPUs(cpus); err != nil {
+	if err := validateMacOSCPUs(cpus); err != nil {
 		return err
 	}
 	// SRC's disk names are reserved: extra --data-disk specs must not collide and the combined count still honors the AHCI cap
@@ -57,6 +61,12 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	var r *record
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, cleanupFailedVM(cmd, dir, r))
+		}
+	}()
 	ctx := cliutil.CommandContext(cmd)
 	storage, err = resizeSystemDisk(ctx, overlay, storage)
 	if err != nil {
@@ -71,7 +81,7 @@ func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	r := &record{
+	r = &record{
 		Name: name, Image: srcRec.Image, ImageDigest: digest, Disk: overlay,
 		OVMFCode: srcRec.OVMFCode, OVMFVars: ovmfVars, CPUs: cpus, Memory: srcRec.Memory, Storage: storage,
 		DataDisks: append(copied, newDisks...),

--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -46,7 +47,7 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	disk := filepath.Join(vmDir, "disk.qcow2")
-	process := exec.Command(fakeQEMU, "-c", "sleep 60", disk)
+	process := exec.Command(fakeQEMU, "-c", "while :; do sleep 1; done", disk)
 	if err := process.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -81,6 +82,71 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 	}
 	if got.PID != rec.PID || got.VNCDisp != 1 {
 		t.Fatalf("live record changed: pid=%d vnc=%d, want pid=%d vnc=1", got.PID, got.VNCDisp, rec.PID)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	callErr := fn()
+	os.Stdout = original
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output), callErr
+}
+
+func TestStartAdoptsQEMUWhenRecordPIDWasNotCommitted(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process cmdline adoption requires /proc")
+	}
+	stateDir := t.TempDir()
+	vmDir := filepath.Join(stateDir, "vms", "macos-demo")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeQEMU := filepath.Join(t.TempDir(), qemuBinary)
+	if err := os.Symlink("/bin/sh", fakeQEMU); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vmDir, "disk.qcow2")
+	process := exec.Command(fakeQEMU, "-c", "while :; do sleep 1; done", disk)
+	if err := process.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = process.Process.Kill()
+		_ = process.Wait()
+	})
+	if err := saveRec(vmDir, &record{Name: "macos-demo", Disk: disk, VNCDisp: -1}); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("state-dir", stateDir, "")
+	cmd.Flags().Int("vnc", -1, "")
+	cmd.Flags().String("vnc-password", "", "")
+	if err := NewHandler().Start(cmd, []string{"macos-demo"}); err != nil {
+		t.Fatalf("Start must adopt the already-running QEMU: %v", err)
+	}
+	got, err := loadRec(vmDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PID != process.Process.Pid {
+		t.Fatalf("adopted PID = %d, want %d", got.PID, process.Process.Pid)
 	}
 }
 

--- a/cmd/vm/handler_test.go
+++ b/cmd/vm/handler_test.go
@@ -85,29 +85,6 @@ func TestStartAlreadyRunningIsIdempotent(t *testing.T) {
 	}
 }
 
-func captureStdout(t *testing.T, fn func() error) (string, error) {
-	t.Helper()
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	original := os.Stdout
-	os.Stdout = writer
-	callErr := fn()
-	os.Stdout = original
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-	output, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := reader.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return string(output), callErr
-}
-
 func TestStartAdoptsQEMUWhenRecordPIDWasNotCommitted(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("process cmdline adoption requires /proc")

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,27 +18,39 @@ import (
 )
 
 func (h *Handler) Create(cmd *cobra.Command, args []string) error {
-	r, err := h.create(cmd, args[0])
-	if err != nil {
-		return err
-	}
-	fmt.Println(r.Name)
-	return nil
+	name := requestedVMName(cmd, "macos-"+time.Now().Format("20060102-150405"))
+	return withVMLock(cliutil.CommandContext(cmd), home.VMDir(cmd, name), func() error {
+		r, err := h.create(cmd, args[0], name)
+		if err != nil {
+			return err
+		}
+		fmt.Println(r.Name)
+		return nil
+	})
 }
 
 func (h *Handler) Run(cmd *cobra.Command, args []string) error {
-	r, err := h.create(cmd, args[0])
-	if err != nil {
-		return err
+	name := requestedVMName(cmd, "macos-"+time.Now().Format("20060102-150405"))
+	dir := home.VMDir(cmd, name)
+	return withVMLock(cliutil.CommandContext(cmd), dir, func() error {
+		r, err := h.create(cmd, args[0], name)
+		if err != nil {
+			return err
+		}
+		if err := h.launch(cmd, dir, r); err != nil {
+			return errors.Join(err, cleanupFailedVM(cmd, dir, r))
+		}
+		fmt.Printf("%s (pid %d)\n", r.Name, r.PID)
+		return nil
+	})
+}
+
+func requestedVMName(cmd *cobra.Command, fallback string) string {
+	name, _ := cmd.Flags().GetString("name")
+	if name != "" {
+		return name
 	}
-	if err := h.launch(cmd, home.VMDir(cmd, r.Name), r); err != nil {
-		// atomic create+boot: remove everything on failure or the leftover record bricks retries; start must NOT do this — its network is persisted
-		teardownNet(cmd, r)
-		_ = os.RemoveAll(home.VMDir(cmd, r.Name))
-		return err
-	}
-	fmt.Printf("%s (pid %d)\n", r.Name, r.PID)
-	return nil
+	return fallback
 }
 
 func (h *Handler) Start(cmd *cobra.Command, args []string) error {
@@ -51,8 +64,23 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			// An op that held the lock may have restarted qemu; adopt it and only repair a dead VNC proxy.
-			if isRunning(r) {
+			// Another lifecycle operation may have restarted qemu while Start waited,
+			// or the previous CLI may have died after daemonizing QEMU but before
+			// persisting its PID. Adopt that one process instead of launching a second.
+			running := isRunning(r)
+			if !running {
+				var adoptErr error
+				running, adoptErr = adoptRunningQEMU(r)
+				if adoptErr != nil {
+					return adoptErr
+				}
+				if running {
+					if err := saveRec(dir, r); err != nil {
+						return err
+					}
+				}
+			}
+			if running {
 				if r.Netns != "" && r.VNCDisp >= 0 && !vncProxyRunning(dir) {
 					if err := startVNCProxy(ctx, dir, r.VNCDisp); err != nil {
 						return fmt.Errorf("repair vnc proxy: %w", err)
@@ -107,16 +135,26 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 	ctx := cliutil.CommandContext(cmd)
 	for _, n := range args {
 		dir := home.VMDir(cmd, n)
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			fmt.Println(n) // nothing to remove (and no dir to hold the flock in)
-			continue
-		}
-		// the flock stops a concurrent start relaunching qemu between terminate and RemoveAll
 		if err := withVMLock(ctx, dir, func() error {
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				return nil
+			} else if err != nil {
+				return fmt.Errorf("stat vm dir: %w", err)
+			}
+			// the flock stops a concurrent create/start from changing state between terminate and RemoveAll
 			if r, err := loadRec(dir); err == nil {
 				terminate(ctx, r, grace)
 				stopVNCProxy(ctx, dir)
 				teardownNet(cmd, r)
+			} else {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
+				defer cancel()
+				if cleanupErr := cleanupQEMUForPath(cleanupCtx, dir); cleanupErr != nil {
+					return cleanupErr
+				}
+				if cleanupErr := qemu.CleanupNBDForPath(cleanupCtx, dir); cleanupErr != nil {
+					return cleanupErr
+				}
 			}
 			if err := os.RemoveAll(dir); err != nil {
 				return fmt.Errorf("remove vm dir: %w", err)
@@ -130,11 +168,7 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
-	name, _ := cmd.Flags().GetString("name")
-	if name == "" {
-		name = "macos-" + time.Now().Format("20060102-150405")
-	}
+func (h *Handler) create(cmd *cobra.Command, image, name string) (r *record, retErr error) {
 	rawDisks, _ := cmd.Flags().GetStringArray("data-disk")
 	diskSpecs, err := parseDataDisks(rawDisks, nil) // fail fast before any scaffolding
 	if err != nil {
@@ -162,6 +196,11 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, cleanupFailedVM(cmd, dir, r))
+		}
+	}()
 	ctx := cliutil.CommandContext(cmd)
 	storage, err = resizeSystemDisk(ctx, overlay, storage)
 	if err != nil {
@@ -173,7 +212,7 @@ func (h *Handler) create(cmd *cobra.Command, image string) (*record, error) {
 	tap, _ := cmd.Flags().GetString("tap")
 	huge, _ := cmd.Flags().GetBool("hugepages")
 	exitOnReboot, _ := cmd.Flags().GetBool("exit-on-reboot")
-	r := &record{
+	r = &record{
 		Name: name, Image: image, ImageDigest: digest, Disk: overlay, OVMFCode: code, OVMFVars: ovmfVars,
 		CPUs: cpus, Memory: mem, Storage: storage, VNCDisp: vnc, SSHPort: ssh, VNCPass: vncPass, NetMode: netMode, Tap: tap, Hugepages: huge,
 		ExitOnReboot: exitOnReboot,
@@ -198,6 +237,30 @@ func validateMacOSCPUs(cpus int) error {
 		return fmt.Errorf("--cpus must be a positive even number, got %d", cpus)
 	}
 	return nil
+}
+
+// cleanupFailedVM makes create/run transactional. It uses an uncanceled,
+// bounded context so SIGTERM-driven command cancellation still reaps helpers,
+// networking and any QEMU process started before the record was committed.
+func cleanupFailedVM(cmd *cobra.Command, dir string, r *record) error {
+	ctx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
+	defer cancel()
+	var errs []error
+	if r != nil {
+		terminate(ctx, r, 0)
+		stopVNCProxy(ctx, dir)
+		teardownNetContext(ctx, cmd, r)
+	}
+	if err := cleanupQEMUForPath(ctx, dir); err != nil {
+		errs = append(errs, err)
+	}
+	if err := qemu.CleanupNBDForPath(ctx, dir); err != nil {
+		errs = append(errs, err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		errs = append(errs, fmt.Errorf("remove failed vm dir: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
 func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
@@ -238,8 +301,13 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 		stopVNCProxy(ctx, dir)
 		return fmt.Errorf("launch qemu: %w", err)
 	}
-	if pid, err := utils.ReadPIDFile(pidfile); err == nil {
-		r.PID = pid
+	pid, err := utils.ReadPIDFile(pidfile)
+	if err != nil {
+		return fmt.Errorf("read qemu pid file: %w", err)
+	}
+	r.PID = pid
+	if !isRunning(r) {
+		return fmt.Errorf("qemu pid %d is not running for disk %s", r.PID, r.Disk)
 	}
 	if r.VNCPass != "" {
 		if err := setVNCPassword(ctx, spec.MonSock, r.VNCPass); err != nil {

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-macos/home"
+	"github.com/cocoonstack/cocoon-macos/internal/procutil"
 	"github.com/cocoonstack/cocoon-macos/qemu"
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/utils"
@@ -45,14 +46,6 @@ func (h *Handler) Run(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func requestedVMName(cmd *cobra.Command, fallback string) string {
-	name, _ := cmd.Flags().GetString("name")
-	if name != "" {
-		return name
-	}
-	return fallback
-}
-
 func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 	ctx := cliutil.CommandContext(cmd)
 	vnc, _ := cmd.Flags().GetInt("vnc")
@@ -64,9 +57,7 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			// Another lifecycle operation may have restarted qemu while Start waited,
-			// or the previous CLI may have died after daemonizing QEMU but before
-			// persisting its PID. Adopt that one process instead of launching a second.
+			// an op that held the lock (export, a racing run) may have restarted qemu; adopt it and only repair a dead vnc proxy
 			running := isRunning(r)
 			if !running {
 				var adoptErr error
@@ -149,10 +140,10 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 			} else {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
 				defer cancel()
-				if cleanupErr := cleanupQEMUForPath(cleanupCtx, dir); cleanupErr != nil {
+				if cleanupErr := procutil.TerminateByCmdline(cleanupCtx, qemuBinary, dir, 0); cleanupErr != nil {
 					return cleanupErr
 				}
-				if cleanupErr := qemu.CleanupNBDForPath(cleanupCtx, dir); cleanupErr != nil {
+				if cleanupErr := procutil.TerminateByCmdline(cleanupCtx, "qemu-nbd", dir, time.Second); cleanupErr != nil {
 					return cleanupErr
 				}
 			}
@@ -232,37 +223,6 @@ func (h *Handler) create(cmd *cobra.Command, image, name string) (r *record, ret
 	return r, saveRec(dir, r)
 }
 
-func validateMacOSCPUs(cpus int) error {
-	if cpus < 1 || cpus%2 != 0 {
-		return fmt.Errorf("--cpus must be a positive even number, got %d", cpus)
-	}
-	return nil
-}
-
-// cleanupFailedVM makes create/run transactional. It uses an uncanceled,
-// bounded context so SIGTERM-driven command cancellation still reaps helpers,
-// networking and any QEMU process started before the record was committed.
-func cleanupFailedVM(cmd *cobra.Command, dir string, r *record) error {
-	ctx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
-	defer cancel()
-	var errs []error
-	if r != nil {
-		terminate(ctx, r, 0)
-		stopVNCProxy(ctx, dir)
-		teardownNetContext(ctx, cmd, r)
-	}
-	if err := cleanupQEMUForPath(ctx, dir); err != nil {
-		errs = append(errs, err)
-	}
-	if err := qemu.CleanupNBDForPath(ctx, dir); err != nil {
-		errs = append(errs, err)
-	}
-	if err := os.RemoveAll(dir); err != nil {
-		errs = append(errs, fmt.Errorf("remove failed vm dir: %w", err))
-	}
-	return errors.Join(errs...)
-}
-
 func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 	ctx := cliutil.CommandContext(cmd)
 	logger := log.WithFunc("cmd.vm.launch")
@@ -323,6 +283,43 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 		}
 	}
 	return saveRec(dir, r)
+}
+
+func requestedVMName(cmd *cobra.Command, fallback string) string {
+	name, _ := cmd.Flags().GetString("name")
+	if name != "" {
+		return name
+	}
+	return fallback
+}
+
+func validateMacOSCPUs(cpus int) error {
+	if cpus < 1 || cpus%2 != 0 {
+		return fmt.Errorf("--cpus must be a positive even number, got %d", cpus)
+	}
+	return nil
+}
+
+// cleanupFailedVM uses an uncanceled bounded context so cancellation still reaps helpers, networking and QEMU.
+func cleanupFailedVM(cmd *cobra.Command, dir string, r *record) error {
+	ctx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
+	defer cancel()
+	var errs []error
+	if r != nil {
+		terminate(ctx, r, 0)
+		stopVNCProxy(ctx, dir)
+		teardownNetContext(ctx, cmd, r)
+	}
+	if err := procutil.TerminateByCmdline(ctx, qemuBinary, dir, 0); err != nil {
+		errs = append(errs, err)
+	}
+	if err := procutil.TerminateByCmdline(ctx, "qemu-nbd", dir, time.Second); err != nil {
+		errs = append(errs, err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		errs = append(errs, fmt.Errorf("remove failed vm dir: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
 // prepareOpenCore points r.OpenCore at the shared base, or with randomSMBIOS at a per-VM overlay whose config.plist is patched with a unique identity.

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -89,10 +89,13 @@ func provisionNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err er
 
 // teardownNet removes an auto-created TAP/netns. Best-effort; never touches a user-supplied --tap.
 func teardownNet(cmd *cobra.Command, r *record) {
+	teardownNetContext(cliutil.CommandContext(cmd), cmd, r)
+}
+
+func teardownNetContext(ctx context.Context, cmd *cobra.Command, r *record) {
 	if !r.TapOwned {
 		return
 	}
-	ctx := cliutil.CommandContext(cmd)
 	logger := log.WithFunc("cmd.vm.teardownNet")
 	// warn instead of failing: rm must proceed, but a leaked TAP/netns should leave a trail
 	if provider, err := newProvider(cmd, r); err != nil {

--- a/cmd/vm/net_other.go
+++ b/cmd/vm/net_other.go
@@ -17,6 +17,8 @@ func provisionNet(_ *cobra.Command, _ *record) (tap, netns, mac string, err erro
 
 func teardownNet(_ *cobra.Command, _ *record) {}
 
+func teardownNetContext(_ context.Context, _ *cobra.Command, _ *record) {}
+
 func quiesceNet(_ *cobra.Command, _ *record) {}
 
 func unquiesceNet(_ *cobra.Command, _ *record) {}

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -15,12 +15,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-macos/home"
+	"github.com/cocoonstack/cocoon-macos/qemu"
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/types"
 	"github.com/cocoonstack/cocoon/utils"
 )
+
+const vmCleanupTimeout = 30 * time.Second
 
 func loadRec(dir string) (*record, error) {
 	var r record
@@ -38,13 +41,19 @@ func saveRec(dir string, r *record) error {
 	return nil
 }
 
-// withVMLock serializes concurrent lifecycle ops on one VM (vm.json is read-modify-write).
+// withVMLock serializes concurrent lifecycle ops on one VM. The lock lives
+// outside the VM directory so rm/retry cannot unlink the inode while another
+// process is waiting on it and accidentally split mutual exclusion.
 func withVMLock(ctx context.Context, dir string, fn func() error) error {
-	l := flock.New(filepath.Join(dir, "vm.json.lock"))
+	lockPath := filepath.Join(filepath.Dir(dir), ".locks", filepath.Base(dir)+".lock")
+	if err := utils.EnsureDirs(filepath.Dir(lockPath)); err != nil {
+		return fmt.Errorf("create vm lock dir: %w", err)
+	}
+	l := flock.NewTransient(lockPath)
 	if err := l.Lock(ctx); err != nil {
 		return fmt.Errorf("lock vm: %w", err)
 	}
-	defer func() { _ = l.Unlock(ctx) }()
+	defer func() { _ = l.Unlock(context.Background()) }()
 	return fn()
 }
 
@@ -110,14 +119,26 @@ func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir,
 	dir = home.VMDir(cmd, name)
 	if _, statErr := os.Stat(filepath.Join(dir, "vm.json")); statErr == nil {
 		return "", "", "", "", fmt.Errorf("vm %q already exists; rm it first or pick another --name", name)
+	} else if !os.IsNotExist(statErr) {
+		return "", "", "", "", fmt.Errorf("stat vm record: %w", statErr)
 	}
-	if err = utils.EnsureDirs(dir); err != nil {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
+	defer cancel()
+	if err = resetIncompleteVMDir(cleanupCtx, dir); err != nil {
 		return "", "", "", "", err
 	}
 	base, digest, err := resolveBase(cmd, image, name)
 	if err != nil {
 		return "", "", "", "", err
 	}
+	if err = utils.EnsureDirs(dir); err != nil {
+		return "", "", "", "", err
+	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(dir)
+		}
+	}()
 	overlay = filepath.Join(dir, "disk.qcow2")
 	if err = bakeOverlay(cliutil.CommandContext(cmd), base, overlay); err != nil {
 		return "", "", "", "", err
@@ -127,6 +148,48 @@ func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir,
 		return "", "", "", "", fmt.Errorf("copy OVMF_VARS: %w", err)
 	}
 	return dir, overlay, ovmfVars, digest, nil
+}
+
+// resetIncompleteVMDir removes state left before vm.json was committed. It
+// refuses to touch a directory referenced by a live QEMU guest, and reaps any
+// stale qemu-nbd helpers before removing their qcow2 paths.
+func resetIncompleteVMDir(ctx context.Context, dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat incomplete vm dir: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vm.json")); err == nil {
+		return fmt.Errorf("refuse to remove committed vm dir %s", dir)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat vm record: %w", err)
+	}
+	if pids, err := utils.FindVMMByCmdline(qemuBinary, dir); err != nil {
+		return fmt.Errorf("scan qemu processes for %s: %w", dir, err)
+	} else if len(pids) > 0 {
+		return fmt.Errorf("refuse to replace incomplete vm dir %s: live qemu pids %v", dir, pids)
+	}
+	if err := qemu.CleanupNBDForPath(ctx, dir); err != nil {
+		return fmt.Errorf("cleanup stale qemu-nbd for %s: %w", dir, err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove incomplete vm dir %s: %w", dir, err)
+	}
+	return nil
+}
+
+func cleanupQEMUForPath(ctx context.Context, path string) error {
+	pids, err := utils.FindVMMByCmdline(qemuBinary, path)
+	if err != nil {
+		return fmt.Errorf("scan qemu processes for %s: %w", path, err)
+	}
+	var errs []error
+	for _, pid := range pids {
+		if err := utils.TerminateProcess(ctx, pid, qemuBinary, path, 0); err != nil {
+			errs = append(errs, fmt.Errorf("terminate qemu pid %d: %w", pid, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // prepareNet returns the TAP ifname, netns path (CNI only), and guest MAC; user-mode and a pre-created --tap need no provisioning, every other mode goes through the per-OS provisionNet.
@@ -159,6 +222,25 @@ func applyNet(cmd *cobra.Command, r *record) error {
 // isRunning is PID-reuse-safe: it verifies argv0 + the overlay path in the process cmdline.
 func isRunning(r *record) bool {
 	return utils.VerifyProcessCmdline(r.PID, qemuBinary, r.Disk)
+}
+
+// adoptRunningQEMU repairs a record whose launch was interrupted after QEMU
+// daemonized but before its PID was saved. More than one match is treated as
+// corruption instead of guessing which process owns the disk.
+func adoptRunningQEMU(r *record) (bool, error) {
+	pids, err := utils.FindVMMByCmdline(qemuBinary, r.Disk)
+	if err != nil {
+		return false, fmt.Errorf("scan qemu process for %s: %w", r.Disk, err)
+	}
+	switch len(pids) {
+	case 0:
+		return false, nil
+	case 1:
+		r.PID = pids[0]
+		return true, nil
+	default:
+		return false, fmt.Errorf("multiple qemu processes use disk %s: %v", r.Disk, pids)
+	}
 }
 
 // terminate stops the VM's qemu, verifying the cmdline before signaling; grace=0 means immediate SIGKILL.

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cocoonstack/cocoon-macos/home"
-	"github.com/cocoonstack/cocoon-macos/qemu"
+	"github.com/cocoonstack/cocoon-macos/internal/procutil"
 	"github.com/cocoonstack/cocoon/cmd/cliutil"
 	"github.com/cocoonstack/cocoon/images"
 	"github.com/cocoonstack/cocoon/lock/flock"
@@ -41,9 +41,7 @@ func saveRec(dir string, r *record) error {
 	return nil
 }
 
-// withVMLock serializes concurrent lifecycle ops on one VM. The lock lives
-// outside the VM directory so rm/retry cannot unlink the inode while another
-// process is waiting on it and accidentally split mutual exclusion.
+// lock lives outside the VM dir so rm can't unlink the inode a waiter still holds and split mutual exclusion.
 func withVMLock(ctx context.Context, dir string, fn func() error) error {
 	lockPath := filepath.Join(filepath.Dir(dir), ".locks", filepath.Base(dir)+".lock")
 	if err := utils.EnsureDirs(filepath.Dir(lockPath)); err != nil {
@@ -150,9 +148,7 @@ func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir,
 	return dir, overlay, ovmfVars, digest, nil
 }
 
-// resetIncompleteVMDir removes state left before vm.json was committed. It
-// refuses to touch a directory referenced by a live QEMU guest, and reaps any
-// stale qemu-nbd helpers before removing their qcow2 paths.
+// remove pre-commit VM state; refuses a dir a live qemu still references.
 func resetIncompleteVMDir(ctx context.Context, dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil
@@ -169,27 +165,13 @@ func resetIncompleteVMDir(ctx context.Context, dir string) error {
 	} else if len(pids) > 0 {
 		return fmt.Errorf("refuse to replace incomplete vm dir %s: live qemu pids %v", dir, pids)
 	}
-	if err := qemu.CleanupNBDForPath(ctx, dir); err != nil {
+	if err := procutil.TerminateByCmdline(ctx, "qemu-nbd", dir, time.Second); err != nil {
 		return fmt.Errorf("cleanup stale qemu-nbd for %s: %w", dir, err)
 	}
 	if err := os.RemoveAll(dir); err != nil {
 		return fmt.Errorf("remove incomplete vm dir %s: %w", dir, err)
 	}
 	return nil
-}
-
-func cleanupQEMUForPath(ctx context.Context, path string) error {
-	pids, err := utils.FindVMMByCmdline(qemuBinary, path)
-	if err != nil {
-		return fmt.Errorf("scan qemu processes for %s: %w", path, err)
-	}
-	var errs []error
-	for _, pid := range pids {
-		if err := utils.TerminateProcess(ctx, pid, qemuBinary, path, 0); err != nil {
-			errs = append(errs, fmt.Errorf("terminate qemu pid %d: %w", pid, err))
-		}
-	}
-	return errors.Join(errs...)
 }
 
 // prepareNet returns the TAP ifname, netns path (CNI only), and guest MAC; user-mode and a pre-created --tap need no provisioning, every other mode goes through the per-OS provisionNet.
@@ -224,9 +206,7 @@ func isRunning(r *record) bool {
 	return utils.VerifyProcessCmdline(r.PID, qemuBinary, r.Disk)
 }
 
-// adoptRunningQEMU repairs a record whose launch was interrupted after QEMU
-// daemonized but before its PID was saved. More than one match is treated as
-// corruption instead of guessing which process owns the disk.
+// adopt a qemu that daemonized before its pid was saved; >1 match is corruption, not a guess.
 func adoptRunningQEMU(r *record) (bool, error) {
 	pids, err := utils.FindVMMByCmdline(qemuBinary, r.Disk)
 	if err != nil {

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -1,6 +1,9 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +43,75 @@ func TestStorageFromFlag(t *testing.T) {
 				t.Fatalf("storageFromFlag() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWithVMLockSurvivesVMDirRemoval(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "vms", "demo")
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := withVMLock(t.Context(), dir, func() error {
+			close(acquired)
+			<-release
+			return nil
+		}); err != nil {
+			t.Errorf("first lock: %v", err)
+		}
+	}()
+	<-acquired
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	second := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := withVMLock(t.Context(), dir, func() error {
+			close(second)
+			return nil
+		}); err != nil {
+			t.Errorf("second lock: %v", err)
+		}
+	}()
+	select {
+	case <-second:
+		t.Fatal("second operation acquired while first still held the VM lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestResetIncompleteVMDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "vms", "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "OpenCore.qcow2"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := resetIncompleteVMDir(t.Context(), dir); err != nil {
+		t.Fatalf("reset incomplete dir: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("incomplete directory still exists: %v", err)
+	}
+}
+
+func TestResetIncompleteVMDirRefusesCommittedRecord(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "vms", "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vm.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := resetIncompleteVMDir(t.Context(), dir); err == nil {
+		t.Fatal("committed VM directory was accepted as incomplete")
 	}
 }
 

--- a/internal/procutil/terminate.go
+++ b/internal/procutil/terminate.go
@@ -1,0 +1,25 @@
+package procutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+// TerminateByCmdline stops matching processes after verifying their command-line identity.
+func TerminateByCmdline(ctx context.Context, binary, path string, grace time.Duration) error {
+	pids, err := utils.FindVMMByCmdline(binary, path)
+	if err != nil {
+		return fmt.Errorf("scan %s processes for %s: %w", binary, path, err)
+	}
+	var errs []error
+	for _, pid := range pids {
+		if err := utils.TerminateProcess(ctx, pid, binary, path, grace); err != nil {
+			errs = append(errs, fmt.Errorf("terminate %s pid %d: %w", binary, pid, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/qemu/inject.go
+++ b/qemu/inject.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projecteru2/core/log"
 	"howett.net/plist"
 
+	"github.com/cocoonstack/cocoon-macos/internal/procutil"
 	"github.com/cocoonstack/cocoon/lock/flock"
 	"github.com/cocoonstack/cocoon/utils"
 )
@@ -155,17 +156,7 @@ func isFileHeld(ocPath string) (bool, error) {
 
 // cleanupNBDForPath terminates qemu-nbd holders of path; PID identity is verified so a reused PID is never hit.
 func cleanupNBDForPath(ctx context.Context, path string) error {
-	pids, err := utils.FindVMMByCmdline("qemu-nbd", path)
-	if err != nil {
-		return fmt.Errorf("scan qemu-nbd processes for %s: %w", path, err)
-	}
-	var errs []error
-	for _, pid := range pids {
-		if err := utils.TerminateProcess(ctx, pid, "qemu-nbd", path, time.Second); err != nil {
-			errs = append(errs, fmt.Errorf("terminate qemu-nbd pid %d: %w", pid, err))
-		}
-	}
-	return errors.Join(errs...)
+	return procutil.TerminateByCmdline(ctx, "qemu-nbd", path, time.Second)
 }
 
 // holds the nbd lease; --fork or qemu-nbd stays foreground and the caller never reaches mount/patch.


### PR DESCRIPTION
## Summary

- serialize create, run, clone, start, stop, and remove operations by VM name using a lock outside the removable VM directory
- clean up partial VM directories, QEMU processes, qemu-nbd helpers, VNC proxies, and owned networking when creation fails or is canceled
- verify the daemonized QEMU PID before committing it, and let `start` adopt a QEMU process when the CLI was interrupted before saving the PID

## Root cause

VM creation spans filesystem scaffolding, OpenCore/NBD injection, networking, QEMU daemonization, and record persistence. Cancellation or failure between those steps could leave partial state. The old lock file also lived inside the directory removed by `rm`, allowing concurrent operations to lock different inodes.

## Impact

Failed or interrupted VM creation becomes retryable without manual cleanup, concurrent lifecycle commands remain serialized, and an already-running guest is not duplicated when its PID record was not committed.

## Dependency

This is a stacked draft based on the changes proposed in #30 and #31. Those commits are included temporarily so the combined behavior can be tested. After #30 and #31 merge, this branch will be rebased onto `master`, leaving only the transactional-create commit for review.

## Validation

- `GOWORK=off go test ./...`
- `make fmt-check vet lint`
- lint and vet passed for both Linux and Darwin targets
