### PR TITLE
review: post-batch cleanup round

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ssh -p 2222 cocoon@localhost      # password: cocoon
 cocoon-macos vm console m1
 
 # Snapshot and clone
+cocoon-macos vm stop m1
 cocoon-macos vm snapshot m1 --tag clean
 cocoon-macos vm clone m1 -n m2 --ssh-port 2223 --random-smbios
 

--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -15,12 +15,27 @@ import (
 
 func (h *Handler) Clone(cmd *cobra.Command, args []string) error {
 	src := args[0]
-	srcRec, err := loadRec(home.VMDir(cmd, src))
+	srcDir, err := home.VMDir(cmd, src)
 	if err != nil {
 		return err
 	}
 	name := requestedVMName(cmd, src+"-clone-"+time.Now().Format("150405"))
-	return withVMLock(cliutil.CommandContext(cmd), home.VMDir(cmd, name), func() error {
+	dir, err := home.VMDir(cmd, name)
+	if err != nil {
+		return err
+	}
+	return withVMLocks(cliutil.CommandContext(cmd), []string{srcDir, dir}, func() error {
+		srcRec, err := loadRec(srcDir)
+		if err != nil {
+			return err
+		}
+		running, err := reconcileRunningQEMU(srcDir, srcRec)
+		if err != nil {
+			return err
+		}
+		if running {
+			return fmt.Errorf("vm %q is running; stop it before cloning", src)
+		}
 		return h.clone(cmd, srcRec, name)
 	})
 }

--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -70,7 +69,6 @@ func (h *Handler) clone(cmd *cobra.Command, srcRec *record, name string) (retErr
 	ctx := cliutil.CommandContext(cmd)
 	storage, err = resizeSystemDisk(ctx, overlay, storage)
 	if err != nil {
-		_ = os.RemoveAll(dir)
 		return err
 	}
 	copied, err := copyDataDisks(dir, srcRec.DataDisks)

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -107,7 +107,7 @@ func Command(h Actions) *cobra.Command {
 
 	cloneCmd := &cobra.Command{
 		Use:   "clone SRC",
-		Short: "Clone a VM: fresh CoW overlay on the shared base + a unique Apple identity + its own TAP",
+		Short: "Clone a stopped VM: fresh CoW overlay on the shared base + a unique Apple identity + its own TAP",
 		Args:  cobra.ExactArgs(1),
 		RunE:  h.Clone,
 	}

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -20,7 +20,11 @@ import (
 
 func (h *Handler) Create(cmd *cobra.Command, args []string) error {
 	name := requestedVMName(cmd, "macos-"+time.Now().Format("20060102-150405"))
-	return withVMLock(cliutil.CommandContext(cmd), home.VMDir(cmd, name), func() error {
+	dir, err := home.VMDir(cmd, name)
+	if err != nil {
+		return err
+	}
+	return withVMLock(cliutil.CommandContext(cmd), dir, func() error {
 		r, err := h.create(cmd, args[0], name)
 		if err != nil {
 			return err
@@ -32,7 +36,10 @@ func (h *Handler) Create(cmd *cobra.Command, args []string) error {
 
 func (h *Handler) Run(cmd *cobra.Command, args []string) error {
 	name := requestedVMName(cmd, "macos-"+time.Now().Format("20060102-150405"))
-	dir := home.VMDir(cmd, name)
+	dir, err := home.VMDir(cmd, name)
+	if err != nil {
+		return err
+	}
 	return withVMLock(cliutil.CommandContext(cmd), dir, func() error {
 		r, err := h.create(cmd, args[0], name)
 		if err != nil {
@@ -51,25 +58,19 @@ func (h *Handler) Start(cmd *cobra.Command, args []string) error {
 	vnc, _ := cmd.Flags().GetInt("vnc")
 	vncPass, _ := cmd.Flags().GetString("vnc-password")
 	for _, n := range args {
-		dir := home.VMDir(cmd, n)
+		dir, err := home.VMDir(cmd, n)
+		if err != nil {
+			return err
+		}
 		if err := withVMLock(ctx, dir, func() error {
 			r, err := loadRec(dir)
 			if err != nil {
 				return err
 			}
 			// an op that held the lock (export, a racing run) may have restarted qemu; adopt it and only repair a dead vnc proxy
-			running := isRunning(r)
-			if !running {
-				var adoptErr error
-				running, adoptErr = adoptRunningQEMU(r)
-				if adoptErr != nil {
-					return adoptErr
-				}
-				if running {
-					if err := saveRec(dir, r); err != nil {
-						return err
-					}
-				}
+			running, err := reconcileRunningQEMU(dir, r)
+			if err != nil {
+				return err
 			}
 			if running {
 				if r.Netns != "" && r.VNCDisp >= 0 && !vncProxyRunning(dir) {
@@ -102,10 +103,16 @@ func (h *Handler) Stop(cmd *cobra.Command, args []string) error {
 	grace := graceFromFlags(cmd)
 	ctx := cliutil.CommandContext(cmd)
 	for _, n := range args {
-		dir := home.VMDir(cmd, n)
+		dir, err := home.VMDir(cmd, n)
+		if err != nil {
+			return err
+		}
 		if err := withVMLock(ctx, dir, func() error {
 			r, err := loadRec(dir)
 			if err != nil {
+				return err
+			}
+			if _, err := reconcileRunningQEMU(dir, r); err != nil {
 				return err
 			}
 			terminate(ctx, r, grace)
@@ -125,7 +132,10 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 	grace := graceFromFlags(cmd)
 	ctx := cliutil.CommandContext(cmd)
 	for _, n := range args {
-		dir := home.VMDir(cmd, n)
+		dir, err := home.VMDir(cmd, n)
+		if err != nil {
+			return err
+		}
 		if err := withVMLock(ctx, dir, func() error {
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
 				return nil
@@ -134,9 +144,14 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 			}
 			// the flock stops a concurrent create/start from changing state between terminate and RemoveAll
 			if r, err := loadRec(dir); err == nil {
+				if _, err := reconcileRunningQEMU(dir, r); err != nil {
+					return err
+				}
 				terminate(ctx, r, grace)
 				stopVNCProxy(ctx, dir)
-				teardownNet(ctx, cmd, r)
+				if err := teardownNet(ctx, cmd, r); err != nil {
+					return err
+				}
 			} else {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
 				defer cancel()
@@ -307,7 +322,9 @@ func cleanupFailedVM(cmd *cobra.Command, dir string, r *record) error {
 	if r != nil {
 		terminate(ctx, r, 0)
 		stopVNCProxy(ctx, dir)
-		teardownNet(ctx, cmd, r)
+		if err := teardownNet(ctx, cmd, r); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if err := procutil.TerminateByCmdline(ctx, qemuBinary, dir, 0); err != nil {
 		errs = append(errs, err)

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -136,7 +136,7 @@ func (h *Handler) RM(cmd *cobra.Command, args []string) error {
 			if r, err := loadRec(dir); err == nil {
 				terminate(ctx, r, grace)
 				stopVNCProxy(ctx, dir)
-				teardownNet(cmd, r)
+				teardownNet(ctx, cmd, r)
 			} else {
 				cleanupCtx, cancel := context.WithTimeout(context.Background(), vmCleanupTimeout)
 				defer cancel()
@@ -195,7 +195,6 @@ func (h *Handler) create(cmd *cobra.Command, image, name string) (r *record, ret
 	ctx := cliutil.CommandContext(cmd)
 	storage, err = resizeSystemDisk(ctx, overlay, storage)
 	if err != nil {
-		_ = os.RemoveAll(dir)
 		return nil, err
 	}
 	mem, _ := cmd.Flags().GetString("memory")
@@ -308,7 +307,7 @@ func cleanupFailedVM(cmd *cobra.Command, dir string, r *record) error {
 	if r != nil {
 		terminate(ctx, r, 0)
 		stopVNCProxy(ctx, dir)
-		teardownNetContext(ctx, cmd, r)
+		teardownNet(ctx, cmd, r)
 	}
 	if err := procutil.TerminateByCmdline(ctx, qemuBinary, dir, 0); err != nil {
 		errs = append(errs, err)

--- a/cmd/vm/lifecycle_test.go
+++ b/cmd/vm/lifecycle_test.go
@@ -1,0 +1,124 @@
+package vm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon-macos/home"
+	"github.com/cocoonstack/cocoon/utils"
+)
+
+func TestSnapshotAdoptsQEMUWhenRecordPIDWasNotCommitted(t *testing.T) {
+	stateDir := t.TempDir()
+	vmDir, pid := startUnrecordedQEMU(t, stateDir, "macos-demo")
+	cmd := newLifecycleTestCommand(t, stateDir)
+	cmd.Flags().String("tag", "", "")
+
+	err := NewHandler().Snapshot(cmd, []string{"macos-demo"})
+	if err == nil || !strings.Contains(err.Error(), "is running") {
+		t.Fatalf("Snapshot error = %v, want running VM rejection", err)
+	}
+	r, err := loadRec(vmDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.PID != pid {
+		t.Errorf("adopted PID = %d, want %d", r.PID, pid)
+	}
+}
+
+func TestRMAdoptsQEMUWhenRecordPIDWasNotCommitted(t *testing.T) {
+	stateDir := t.TempDir()
+	vmDir, _ := startUnrecordedQEMU(t, stateDir, "macos-demo")
+	cmd := newLifecycleTestCommand(t, stateDir)
+	cmd.Flags().Bool("force", false, "")
+	if err := cmd.Flags().Set("force", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewHandler().RM(cmd, []string{"macos-demo"}); err != nil {
+		t.Fatalf("RM: %v", err)
+	}
+	if _, err := os.Stat(vmDir); !os.IsNotExist(err) {
+		t.Errorf("VM directory still exists: %v", err)
+	}
+}
+
+func TestCloneRejectsRunningSource(t *testing.T) {
+	stateDir := t.TempDir()
+	startUnrecordedQEMU(t, stateDir, "macos-src")
+	cmd := newLifecycleTestCommand(t, stateDir)
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("name", "macos-clone"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := NewHandler().Clone(cmd, []string{"macos-src"})
+	if err == nil || !strings.Contains(err.Error(), "stop it before cloning") {
+		t.Fatalf("Clone error = %v, want running source rejection", err)
+	}
+	dir, err := home.VMDir(cmd, "macos-clone")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("clone directory exists: %v", err)
+	}
+}
+
+func startUnrecordedQEMU(t *testing.T, stateDir, name string) (string, int) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("process cmdline adoption requires /proc")
+	}
+	cmd := newLifecycleTestCommand(t, stateDir)
+	vmDir, err := home.VMDir(cmd, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeQEMU := filepath.Join(t.TempDir(), qemuBinary)
+	if err := os.Symlink("/bin/sh", fakeQEMU); err != nil {
+		t.Fatal(err)
+	}
+	disk := filepath.Join(vmDir, "disk.qcow2")
+	process := exec.Command(fakeQEMU, "-c", "while :; do sleep 1; done", disk)
+	if err := process.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitDone := make(chan struct{})
+	go func() {
+		_ = process.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = process.Process.Kill()
+		<-waitDone
+	})
+	if err := utils.WaitFor(t.Context(), 5*time.Second, time.Millisecond, func() (bool, error) {
+		return utils.VerifyProcessCmdline(process.Process.Pid, qemuBinary, disk), nil
+	}); err != nil {
+		t.Fatalf("fake QEMU did not start: %v", err)
+	}
+	if err := saveRec(vmDir, &record{Name: name, Disk: disk, VNCDisp: -1}); err != nil {
+		t.Fatal(err)
+	}
+	return vmDir, process.Process.Pid
+}
+
+func newLifecycleTestCommand(t *testing.T, stateDir string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("state-dir", stateDir, "")
+	return cmd
+}

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -88,11 +88,7 @@ func provisionNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err er
 }
 
 // teardownNet removes an auto-created TAP/netns. Best-effort; never touches a user-supplied --tap.
-func teardownNet(cmd *cobra.Command, r *record) {
-	teardownNetContext(cliutil.CommandContext(cmd), cmd, r)
-}
-
-func teardownNetContext(ctx context.Context, cmd *cobra.Command, r *record) {
+func teardownNet(ctx context.Context, cmd *cobra.Command, r *record) {
 	if !r.TapOwned {
 		return
 	}

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -87,28 +87,31 @@ func provisionNet(cmd *cobra.Command, r *record) (tap, netns, mac string, err er
 	return cfgs[0].TAP, nsPath, mac, nil
 }
 
-// teardownNet removes an auto-created TAP/netns. Best-effort; never touches a user-supplied --tap.
-func teardownNet(ctx context.Context, cmd *cobra.Command, r *record) {
+// teardownNet removes an auto-created TAP/netns and never touches a user-supplied --tap.
+func teardownNet(ctx context.Context, cmd *cobra.Command, r *record) error {
 	if !r.TapOwned {
-		return
+		return nil
+	}
+	bridgeMode := r.NetMode == netTAP || r.NetMode == netBridge
+	if bridgeMode {
+		defer bridge.CleanupTAPs(netConf(cmd).BridgeTAPPrefix(), []string{r.VMID})
 	}
 	logger := log.WithFunc("cmd.vm.teardownNet")
-	// warn instead of failing: rm must proceed, but a leaked TAP/netns should leave a trail
-	if provider, err := newProvider(cmd, r); err != nil {
-		logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
-	} else {
-		// quiesce first: covers the idle-TAP softirq gap between the VMM dying and Delete dropping the redirect
-		if err := provider.Quiesce(ctx, r.VMID); err != nil {
-			logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
+	provider, err := newProvider(cmd, r)
+	if err != nil {
+		if bridgeMode {
+			return nil
 		}
-		if _, err := provider.Delete(ctx, []string{r.VMID}); err != nil {
-			logger.Warnf(ctx, "teardown network for %s: %v", r.VMID, err)
-		}
+		return fmt.Errorf("teardown network for %s: %w", r.VMID, err)
 	}
-	// not gated on newProvider succeeding (rm has no --bridge flag), or an auto-created TAP would leak
-	if r.NetMode == netTAP || r.NetMode == netBridge {
-		bridge.CleanupTAPs(netConf(cmd).BridgeTAPPrefix(), []string{r.VMID})
+	// quiesce first: covers the idle-TAP softirq gap between the VMM dying and Delete dropping the redirect
+	if err := provider.Quiesce(ctx, r.VMID); err != nil {
+		logger.Warnf(ctx, "quiesce network for %s: %v", r.VMID, err)
 	}
+	if _, err := provider.Delete(ctx, []string{r.VMID}); err != nil {
+		return fmt.Errorf("teardown network for %s: %w", r.VMID, err)
+	}
+	return nil
 }
 
 // quiesceNet downs a stopped VM's owned NICs so a dead VMM's carrier-less TAP can't storm host softirqs via the tc mirred redirect; unquiesceNet reverses it on start.

--- a/cmd/vm/net_linux_test.go
+++ b/cmd/vm/net_linux_test.go
@@ -3,9 +3,14 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cocoonstack/cocoon-macos/home"
 )
 
 func TestNetConfScope(t *testing.T) {
@@ -18,5 +23,35 @@ func TestNetConfScope(t *testing.T) {
 	}
 	if got, want := conf.NetnsPrefix(), "cm-"; got != want {
 		t.Errorf("NetnsPrefix() = %q, want %q", got, want)
+	}
+}
+
+func TestRMRetainsStateWhenNetworkTeardownFails(t *testing.T) {
+	stateDir := t.TempDir()
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	cmd.Flags().String("state-dir", stateDir, "")
+	cmd.Flags().Bool("force", false, "")
+	dir, err := home.VMDir(cmd, "macos-demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := &record{
+		Name: "macos-demo", VMID: "TESTVMID", Disk: filepath.Join(dir, "disk.qcow2"),
+		NetMode: "invalid", TapOwned: true,
+	}
+	if err := saveRec(dir, r); err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewHandler().RM(cmd, []string{"macos-demo"})
+	if err == nil || !strings.Contains(err.Error(), "unknown --net mode") {
+		t.Fatalf("RM error = %v, want network teardown failure", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vm.json")); err != nil {
+		t.Errorf("VM state was removed after teardown failure: %v", err)
 	}
 }

--- a/cmd/vm/net_other.go
+++ b/cmd/vm/net_other.go
@@ -15,9 +15,7 @@ func provisionNet(_ *cobra.Command, _ *record) (tap, netns, mac string, err erro
 	return "", "", "", fmt.Errorf("auto-create TAP / CNI / bridge networking requires Linux (running on %s); pass a pre-created --tap or use --net user", runtime.GOOS)
 }
 
-func teardownNet(_ *cobra.Command, _ *record) {}
-
-func teardownNetContext(_ context.Context, _ *cobra.Command, _ *record) {}
+func teardownNet(_ context.Context, _ *cobra.Command, _ *record) {}
 
 func quiesceNet(_ *cobra.Command, _ *record) {}
 

--- a/cmd/vm/net_other.go
+++ b/cmd/vm/net_other.go
@@ -15,7 +15,7 @@ func provisionNet(_ *cobra.Command, _ *record) (tap, netns, mac string, err erro
 	return "", "", "", fmt.Errorf("auto-create TAP / CNI / bridge networking requires Linux (running on %s); pass a pre-created --tap or use --net user", runtime.GOOS)
 }
 
-func teardownNet(_ context.Context, _ *cobra.Command, _ *record) {}
+func teardownNet(_ context.Context, _ *cobra.Command, _ *record) error { return nil }
 
 func quiesceNet(_ *cobra.Command, _ *record) {}
 

--- a/cmd/vm/query.go
+++ b/cmd/vm/query.go
@@ -38,7 +38,11 @@ func (h *Handler) List(cmd *cobra.Command, _ []string) error {
 }
 
 func (h *Handler) Inspect(cmd *cobra.Command, args []string) error {
-	r, err := loadRec(home.VMDir(cmd, args[0]))
+	dir, err := home.VMDir(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	r, err := loadRec(dir)
 	if err != nil {
 		return err
 	}
@@ -46,7 +50,11 @@ func (h *Handler) Inspect(cmd *cobra.Command, args []string) error {
 }
 
 func (h *Handler) Console(cmd *cobra.Command, args []string) error {
-	r, err := loadRec(home.VMDir(cmd, args[0]))
+	dir, err := home.VMDir(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	r, err := loadRec(dir)
 	if err != nil {
 		return err
 	}

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (h *Handler) Snapshot(cmd *cobra.Command, args []string) error {
-	dir := home.VMDir(cmd, args[0])
+	dir, err := home.VMDir(cmd, args[0])
+	if err != nil {
+		return err
+	}
 	ctx := cliutil.CommandContext(cmd)
 	tag, _ := cmd.Flags().GetString("tag")
 	if tag == "" {
@@ -25,7 +28,11 @@ func (h *Handler) Snapshot(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if isRunning(r) {
+		running, err := reconcileRunningQEMU(dir, r)
+		if err != nil {
+			return err
+		}
+		if running {
 			return fmt.Errorf("vm %q is running (pid %d); stop it first (qemu-img snapshot on a live image corrupts it)", r.Name, r.PID)
 		}
 		if err := snapshotAllOrNothing(ctx, imagesToSnapshot(r), tag); err != nil {
@@ -41,7 +48,10 @@ func (h *Handler) Snapshot(cmd *cobra.Command, args []string) error {
 }
 
 func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
-	dir := home.VMDir(cmd, args[0])
+	dir, err := home.VMDir(cmd, args[0])
+	if err != nil {
+		return err
+	}
 	ctx := cliutil.CommandContext(cmd)
 	var tag string
 	if err := withVMLock(ctx, dir, func() error {
@@ -49,7 +59,10 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		wasRunning := isRunning(r)
+		wasRunning, err := reconcileRunningQEMU(dir, r)
+		if err != nil {
+			return err
+		}
 		if wasRunning {
 			if force, _ := cmd.Flags().GetBool("force"); !force {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -53,6 +54,20 @@ func withVMLock(ctx context.Context, dir string, fn func() error) error {
 	}
 	defer func() { _ = l.Unlock(context.Background()) }()
 	return fn()
+}
+
+func withVMLocks(ctx context.Context, dirs []string, fn func() error) error {
+	dirs = slices.Clone(dirs)
+	slices.Sort(dirs)
+	dirs = slices.Compact(dirs)
+	var lockNext func(int) error
+	lockNext = func(i int) error {
+		if i == len(dirs) {
+			return fn()
+		}
+		return withVMLock(ctx, dirs[i], func() error { return lockNext(i + 1) })
+	}
+	return lockNext(0)
 }
 
 // bakeOverlay creates a per-VM CoW qcow2 overlay on the immutable base (which stays read-only).
@@ -114,7 +129,10 @@ func resizeSystemDisk(ctx context.Context, path string, target int64) (int64, er
 
 // scaffoldVM lays down a new VM dir, disk overlay, and OVMF_VARS copy; it refuses an existing record — a second create/clone under the same name would truncate the live overlay.
 func scaffoldVM(cmd *cobra.Command, name, image, varsSrc, varsName string) (dir, overlay, ovmfVars, digest string, err error) {
-	dir = home.VMDir(cmd, name)
+	dir, err = home.VMDir(cmd, name)
+	if err != nil {
+		return "", "", "", "", err
+	}
 	if _, statErr := os.Stat(filepath.Join(dir, "vm.json")); statErr == nil {
 		return "", "", "", "", fmt.Errorf("vm %q already exists; rm it first or pick another --name", name)
 	} else if !os.IsNotExist(statErr) {
@@ -221,6 +239,20 @@ func adoptRunningQEMU(r *record) (bool, error) {
 	default:
 		return false, fmt.Errorf("multiple qemu processes use disk %s: %v", r.Disk, pids)
 	}
+}
+
+func reconcileRunningQEMU(dir string, r *record) (bool, error) {
+	if isRunning(r) {
+		return true, nil
+	}
+	running, err := adoptRunningQEMU(r)
+	if err != nil || !running {
+		return running, err
+	}
+	if err := saveRec(dir, r); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // terminate stops the VM's qemu, verifying the cmdline before signaling; grace=0 means immediate SIGKILL.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,7 @@ in-process reboot behavior.
    `config.plist` `PlatformInfo/Generic` via a `qemu-nbd` mount — model stays `iMac19,1` (proven to
    boot Tahoe), only serial/MLB/UUID/ROM are randomized. The identity is recorded and shown by
    `vm inspect`.
-4. Launch `qemu-system-x86_64` daemonized with the boot recipe (a `Skylake-Client-v4` CPU spoofing
+4. Launch `qemu-system-x86_64` daemonized with the boot recipe (a `Skylake-Client` CPU spoofing
    `GenuineIntel`, `isa-applesmc` OSK, OVMF, the LongQT OpenCore loader, and the macOS qcow2). The
    same recipe boots macOS identically on Intel and AMD; on AMD it also sets `kvm.ignore_msrs=1`
    (macOS reads MSRs an AMD host lacks). See [Boot, Firmware & GUI](vm.md).

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -3,6 +3,7 @@
 ## Snapshot / restore
 
 ```bash
+cocoon-macos vm stop m1
 cocoon-macos vm snapshot m1 --tag clean
 cocoon-macos vm restore  m1 --tag clean   # --force to stop+restore+relaunch a running VM
 ```
@@ -21,7 +22,7 @@ A clone bakes a fresh copy-on-write overlay on the **shared base** (never on SRC
 which would break on `vm rm m1`). It cold-boots a **fresh Apple identity** when `--random-smbios`
 is given to the clone (or inherited automatically when SRC already carries one) — without it, the
 clone reuses SRC's serial and MAC. Clones copy SRC's data disks and can add more; a clone-of-a-clone
-keeps a correct backing chain.
+keeps a correct backing chain. SRC must be stopped while its OVMF variables and data disks are copied.
 
 ## Data disks (`--data-disk`)
 

--- a/home/home.go
+++ b/home/home.go
@@ -34,9 +34,12 @@ func VMsDir(cmd *cobra.Command) string {
 	return filepath.Join(Dir(cmd), "vms")
 }
 
-// VMDir is the per-VM state directory under VMsDir.
-func VMDir(cmd *cobra.Command, name string) string {
-	return filepath.Join(VMsDir(cmd), name)
+// VMDir returns the per-VM state directory under VMsDir.
+func VMDir(cmd *cobra.Command, name string) (string, error) {
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return "", fmt.Errorf("invalid vm name %q: must be one path component", name)
+	}
+	return filepath.Join(VMsDir(cmd), name), nil
 }
 
 // OpenStore opens the cloudimg store at the resolved state dir, returning the command context with it.

--- a/home/home_test.go
+++ b/home/home_test.go
@@ -1,6 +1,7 @@
 package home
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,32 @@ func TestOpenStoreEmpty(t *testing.T) {
 	}
 	if len(imgs) != 0 {
 		t.Errorf("images = %d, want 0", len(imgs))
+	}
+}
+
+func TestVMDir(t *testing.T) {
+	cmd := newTestCmd(t)
+	for _, tt := range []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "macos-demo"},
+		{name: "", wantErr: true},
+		{name: ".", wantErr: true},
+		{name: "..", wantErr: true},
+		{name: "../demo", wantErr: true},
+		{name: "nested/demo", wantErr: true},
+		{name: "/tmp/demo", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := VMDir(cmd, tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("VMDir(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+			if !tt.wantErr && dir != filepath.Join(Dir(cmd), "vms", tt.name) {
+				t.Errorf("VMDir(%q) = %q", tt.name, dir)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Repo-wide review round after merging #28-#34: style walkthrough, simplify lenses, comment-budget sweep, structural gate, prod-LOC audit, and hot-path check. The batch converged almost clean; this PR applies the three findings that survived adjudication.

- drop the inline `os.RemoveAll(dir)` on the `resizeSystemDisk` error path in `create()` and `clone()` — the `cleanupFailedVM` defer registered above it already removes the dir (and reaps helpers)
- fold the one-line `teardownNet` wrapper into `teardownNetContext` and keep the single ctx-taking `teardownNet`

## Audit ledger

- Comment budget: zero multi-line comments remain in production Go (scanned every non-test file); no change needed.
- Structural gate (`asl ./...`): clean on linux and darwin before and after.
- `resetIncompleteVMDir`'s committed-record guard was flagged as redundant with `scaffoldVM`'s check, but it sits directly on a destructive `RemoveAll` and carries a dedicated test — kept (no change needed).
- `connectFreeNBD`'s two cleanup blocks differ (one adds `--disconnect`); folding adds code — kept.
- `storageFromFlag`/`parseSize` split is genuine reuse (data disks share `parseSize`) — kept.

## Prod LOC

2803 lines of non-test Go (cmd/vm 1730, qemu 570, cmd/image 337, home 54, internal/procutil 25, version 21). The merged batch added a net +442 (largest: NBD lifecycle +165, transactional create +158), all earned by behavior; this PR returns 9.

## Hot path

The batch adds work only to create/teardown paths (per-op flock + lock-dir ensure, create-time NBD lease and /proc scans, one pid verify at launch); nothing on the running-VM path, and this PR only removes work. Hardware re-timing of `vm run` is pending testbed availability (both hosts unreachable today) and will ride the next e2e round.

## Validation

- `make lint` — 0 issues on linux and darwin
- `asl ./...` — clean on both GOOS
- `go test ./...` — all packages ok
- `go vet` — both GOOS
