### PR TITLE
fix: restore --force relaunches under the launch-scoped VNC contract

### DIFF
--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -117,9 +117,7 @@ func (h *Handler) Stop(cmd *cobra.Command, args []string) error {
 			}
 			terminate(ctx, r, grace)
 			quiesceNet(cmd, r)
-			stopVNCProxy(ctx, dir)
-			r.PID, r.VNCDisp, r.VNCPass = 0, -1, "" // VNC is launch-scoped: gone with the qemu it belonged to
-			return saveRec(dir, r)
+			return saveStopped(ctx, dir, r)
 		}); err != nil {
 			return err
 		}
@@ -273,7 +271,6 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 	c := launchCmd(r, args) // CNI: wraps in `ip netns exec` so -netdev tap finds the in-netns TAP
 	c.Stdout, c.Stderr = os.Stdout, os.Stderr
 	if err := c.Run(); err != nil {
-		stopVNCProxy(ctx, dir)
 		return fmt.Errorf("launch qemu: %w", err)
 	}
 	pid, err := utils.ReadPIDFile(pidfile)

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -264,6 +264,7 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 	}
 	pidfile := filepath.Join(dir, "qemu.pid")
 	args := append(spec.Args(), "-daemonize", "-pidfile", pidfile)
+	stopVNCProxy(ctx, dir)
 	ensureNetnsLoopback(ctx, r) // CNI: a fresh netns has lo DOWN, so qemu's -vnc 127.0.0.1 would fail to bind
 	if r.Netns != "" {
 		logger.Debugf(ctx, "running qemu in netns %s via `ip netns exec`", filepath.Base(r.Netns))

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -68,9 +68,7 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
 			terminate(ctx, r, stopGracePeriod)
-			stopVNCProxy(ctx, dir)
-			r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
-			if err := saveRec(dir, r); err != nil {
+			if err := saveStopped(ctx, dir, r); err != nil {
 				return err
 			}
 		}

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -68,8 +68,10 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
 			terminate(ctx, r, stopGracePeriod)
-			stopVNCProxy(ctx, dir)
 			r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
+			if err := saveRec(dir, r); err != nil {
+				return err
+			}
 		}
 		tag, _ = cmd.Flags().GetString("tag")
 		if tag == "" {

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -68,6 +68,7 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
 			terminate(ctx, r, stopGracePeriod)
+			stopVNCProxy(ctx, dir)
 			r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
 			if err := saveRec(dir, r); err != nil {
 				return err

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -68,7 +68,8 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
 			terminate(ctx, r, stopGracePeriod)
-			r.PID = 0
+			stopVNCProxy(ctx, dir)
+			r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
 		}
 		tag, _ = cmd.Flags().GetString("tag")
 		if tag == "" {

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -262,7 +262,7 @@ func terminate(ctx context.Context, r *record, grace time.Duration) {
 	}
 }
 
-// saveStopped persists a VM with no qemu behind it; VNC is launch-scoped, so its proxy and display go with the process.
+// VNC is launch-scoped: the proxy and display go with the qemu process.
 func saveStopped(ctx context.Context, dir string, r *record) error {
 	stopVNCProxy(ctx, dir)
 	r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -262,6 +262,13 @@ func terminate(ctx context.Context, r *record, grace time.Duration) {
 	}
 }
 
+// saveStopped persists a VM with no qemu behind it; VNC is launch-scoped, so its proxy and display go with the process.
+func saveStopped(ctx context.Context, dir string, r *record) error {
+	stopVNCProxy(ctx, dir)
+	r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
+	return saveRec(dir, r)
+}
+
 func graceFromFlags(cmd *cobra.Command) time.Duration {
 	if force, _ := cmd.Flags().GetBool("force"); force {
 		return 0


### PR DESCRIPTION
## Problem

`vm restore --force` on a running VM terminates QEMU, reverts the disks, then calls `launch` with the loaded record. `VNCPass` is never persisted (`json:"-"`), but `VNCDisp` is, so the relaunch carried a display number with an empty password:

- CNI VM: `requireCNIVNCPassword` refused the launch after the disks were already reverted, and `saveRec` was never reached, so the record kept the dead PID.
- Non-CNI VM: QEMU came back with VNC on `127.0.0.1:590n` and no password, where the previous incarnation required one.

`Stop` already encodes the contract (`r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""` plus `stopVNCProxy`); `Start` re-enables VNC only from its own flags. Restore was the one launch path that did not follow it.

## Change

Restore's `wasRunning` branch stops the VNC proxy and clears the three launch-scoped fields before relaunching, exactly as `Stop` does.

## Evidence

`GOWORK=off make lint` (linux + darwin): 0 issues ×2. `make fmt-check`: clean. `asl ./...` both GOOS: clean. `go test -race ./...`: green. The restore path has no unit harness (it drives a real QEMU); the change mirrors the stop path line for line.