### PR TITLE
fix: keep the VNC display across a running-origin restore; refuse the CNI case up front

### DIFF
--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -37,6 +37,7 @@ type record struct {
 	Storage      int64    `json:"storage,omitempty"` // system-disk virtual size in bytes
 	VNCDisp      int      `json:"vnc"`
 	VNCPass      string   `json:"-"` // launch-scoped, set from the flag each start; never persisted (would leak at rest)
+	VNCPassSet   bool     `json:"vnc_password_set,omitempty"`
 	SSHPort      int      `json:"ssh_port"`
 	NetMode      string   `json:"net_mode,omitempty"`
 	Hugepages    bool     `json:"hugepages,omitempty"`

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -270,6 +270,10 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 		logger.Debugf(ctx, "running qemu in netns %s via `ip netns exec`", filepath.Base(r.Netns))
 	}
 	logger.Debug(ctx, "booting macOS guest via qemu-system-x86_64 (authoritative VMM; no Go equivalent)")
+	r.VNCPassSet = r.VNCPass != ""
+	if err := saveRec(dir, r); err != nil {
+		return err
+	}
 	c := launchCmd(r, args) // CNI: wraps in `ip netns exec` so -netdev tap finds the in-netns TAP
 	c.Stdout, c.Stderr = os.Stdout, os.Stderr
 	if err := c.Run(); err != nil {
@@ -296,7 +300,6 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 			return fmt.Errorf("start vnc proxy: %w", err)
 		}
 	}
-	r.VNCPassSet = r.VNCPass != ""
 	return saveRec(dir, r)
 }
 

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -118,7 +118,7 @@ func (h *Handler) Stop(cmd *cobra.Command, args []string) error {
 			terminate(ctx, r, grace)
 			quiesceNet(cmd, r)
 			stopVNCProxy(ctx, dir)
-			r.PID, r.VNCDisp, r.VNCPass = 0, -1, "" // VNC is launch-scoped: gone with the qemu it belonged to
+			r.PID, r.VNCDisp, r.VNCPass, r.VNCPassSet = 0, -1, "", false // VNC is launch-scoped: gone with the qemu it belonged to
 			return saveRec(dir, r)
 		}); err != nil {
 			return err
@@ -296,6 +296,7 @@ func (h *Handler) launch(cmd *cobra.Command, dir string, r *record) error {
 			return fmt.Errorf("start vnc proxy: %w", err)
 		}
 	}
+	r.VNCPassSet = r.VNCPass != ""
 	return saveRec(dir, r)
 }
 

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -117,7 +117,9 @@ func (h *Handler) Stop(cmd *cobra.Command, args []string) error {
 			}
 			terminate(ctx, r, grace)
 			quiesceNet(cmd, r)
-			return saveStopped(ctx, dir, r)
+			stopVNCProxy(ctx, dir)
+			r.PID, r.VNCDisp, r.VNCPass = 0, -1, "" // VNC is launch-scoped: gone with the qemu it belonged to
+			return saveRec(dir, r)
 		}); err != nil {
 			return err
 		}

--- a/cmd/vm/lifecycle_test.go
+++ b/cmd/vm/lifecycle_test.go
@@ -51,6 +51,30 @@ func TestRMAdoptsQEMUWhenRecordPIDWasNotCommitted(t *testing.T) {
 	}
 }
 
+func TestRestoreRefusesRunningPasswordedVNC(t *testing.T) {
+	stateDir := t.TempDir()
+	vmDir, pid := startUnrecordedQEMU(t, stateDir, "macos-demo")
+	r, err := loadRec(vmDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.VNCDisp, r.VNCPassSet = 7, true
+	if err := saveRec(vmDir, r); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newLifecycleTestCommand(t, stateDir)
+	cmd.Flags().String("tag", "", "")
+	cmd.Flags().Bool("force", true, "")
+
+	err = NewHandler().Restore(cmd, []string{"macos-demo"})
+	if err == nil || !strings.Contains(err.Error(), "password-gated VNC") {
+		t.Fatalf("Restore error = %v, want the password-gated VNC refusal", err)
+	}
+	if !utils.VerifyProcessCmdline(pid, qemuBinary, filepath.Join(vmDir, "disk.qcow2")) {
+		t.Error("qemu was terminated by a refused restore")
+	}
+}
+
 func TestCloneRejectsRunningSource(t *testing.T) {
 	stateDir := t.TempDir()
 	startUnrecordedQEMU(t, stateDir, "macos-src")

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -67,8 +67,8 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 			if force, _ := cmd.Flags().GetBool("force"); !force {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
-			if r.Netns != "" && r.VNCDisp >= 0 {
-				return fmt.Errorf("vm %q serves VNC over CNI and a relaunch cannot carry its password; stop it, restore, then start --vnc %d --vnc-password", r.Name, r.VNCDisp)
+			if r.VNCDisp >= 0 && (r.VNCPassSet || r.Netns != "") {
+				return fmt.Errorf("vm %q serves a password-gated VNC display and a relaunch cannot carry the password; stop it, restore, then start --vnc %d --vnc-password", r.Name, r.VNCDisp)
 			}
 			terminate(ctx, r, stopGracePeriod)
 			r.PID = 0

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -67,8 +67,12 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 			if force, _ := cmd.Flags().GetBool("force"); !force {
 				return fmt.Errorf("vm %q is running; stop it first or pass --force to stop+restore", r.Name)
 			}
+			if r.Netns != "" && r.VNCDisp >= 0 {
+				return fmt.Errorf("vm %q serves VNC over CNI and a relaunch cannot carry its password; stop it, restore, then start --vnc %d --vnc-password", r.Name, r.VNCDisp)
+			}
 			terminate(ctx, r, stopGracePeriod)
-			if err := saveStopped(ctx, dir, r); err != nil {
+			r.PID = 0
+			if err := saveRec(dir, r); err != nil {
 				return err
 			}
 		}

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -262,13 +262,6 @@ func terminate(ctx context.Context, r *record, grace time.Duration) {
 	}
 }
 
-// VNC is launch-scoped: the proxy and display go with the qemu process.
-func saveStopped(ctx context.Context, dir string, r *record) error {
-	stopVNCProxy(ctx, dir)
-	r.PID, r.VNCDisp, r.VNCPass = 0, -1, ""
-	return saveRec(dir, r)
-}
-
 func graceFromFlags(cmd *cobra.Command) time.Duration {
 	if force, _ := cmd.Flags().GetBool("force"); force {
 		return 0


### PR DESCRIPTION
Follow-up to #36, found by running it against a real sequoia:15 guest on bare metal.

With `--net user`, `vm restore --force` on a running VM relaunched qemu without `-vnc`: the stop tail had cleared VNCDisp before launch read it, so the display was lost after every running-origin restore, while the pre-#36 binary kept it. The display is the VM's persisted configuration; only the password and the proxy are launch-scoped, and a non-CNI VM has no proxy to stop.

- restore's running-origin branch keeps VNCDisp: terminate, zero PID, save the record, apply, relaunch.
- a running origin whose display is password-gated is refused before anything is touched: the relaunch cannot carry the never-persisted password, and before #36 the same case failed inside launch after the disks were already reverted (CNI) or came back unauthenticated (user/tap/bridge). The record carries a non-secret `vnc_password_set` bit, written at launch and cleared at stop; `Netns` stays as the fallback for records written before the bit existed. The error names the working sequence (stop, restore, `start --vnc N --vnc-password`).
- `saveStopped` is gone; Stop keeps its own tail. launch still stops a stale proxy before every relaunch.
- Linux test `TestRestoreRefusesRunningPasswordedVNC` drives the refusal against the fake qemu.

Hardware evidence (`.79`, sequoia:15): pre-#36 binary answers RFB on the display after `restore --force` in user mode; the #36 build does not (qemu alive, no `-vnc`); this branch answers RFB after restore in user mode, refuses the running CNI origin with the display untouched, and stop/restore/`start --vnc --vnc-password` relaunches exactly one proxy.

Gates: `make lint` 0 issues both GOOS, `make fmt-check`, `asl ./...` both GOOS, `go test -race ./...`; the Linux-gated test run on the Linux host.