### PR TITLE
fix: stop VNC proxy before restoring disks

### DIFF
--- a/cmd/vm/lifecycle_test.go
+++ b/cmd/vm/lifecycle_test.go
@@ -76,6 +76,37 @@ func TestRestoreRefusesRunningPasswordedVNC(t *testing.T) {
 	}
 }
 
+func TestRestoreForceStopsVNCProxyWhenApplyIsRefused(t *testing.T) {
+	stateDir := t.TempDir()
+	vmDir, _ := startUnrecordedQEMU(t, stateDir, "macos-demo")
+	r, err := loadRec(vmDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.VNCDisp = 7
+	if err := saveRec(vmDir, r); err != nil {
+		t.Fatal(err)
+	}
+	spawnTestProxy(t, vmDir)
+	cmd := newLifecycleTestCommand(t, stateDir)
+	cmd.Flags().String("tag", "", "")
+	cmd.Flags().Bool("force", true, "")
+	cmd.Flags().String("vnc-password", "", "")
+
+	err = NewHandler().Restore(cmd, []string{"macos-demo"})
+	if err == nil || !strings.Contains(err.Error(), "no snapshots") {
+		t.Fatalf("Restore error = %v, want the no-snapshots refusal after the stop", err)
+	}
+	if _, err := os.Stat(filepath.Join(vmDir, vncProxyPID)); !os.IsNotExist(err) {
+		t.Errorf("proxy pid file survived the refused restore: %v", err)
+	}
+	if err := utils.WaitFor(t.Context(), 2*time.Second, 10*time.Millisecond, func() (bool, error) {
+		return !vncProxyRunning(vmDir), nil
+	}); err != nil {
+		t.Errorf("proxy still running after the refused restore: %v", err)
+	}
+}
+
 func TestCloneRejectsRunningSource(t *testing.T) {
 	stateDir := t.TempDir()
 	startUnrecordedQEMU(t, stateDir, "macos-src")

--- a/cmd/vm/snapshot.go
+++ b/cmd/vm/snapshot.go
@@ -76,6 +76,7 @@ func (h *Handler) Restore(cmd *cobra.Command, args []string) error {
 			}
 			r.VNCPass = vncPass
 			terminate(ctx, r, stopGracePeriod)
+			stopVNCProxy(ctx, dir)
 			r.PID = 0
 			if err := saveRec(dir, r); err != nil {
 				return err

--- a/cmd/vm/vnc_test.go
+++ b/cmd/vm/vnc_test.go
@@ -66,19 +66,7 @@ func TestVNCProxyRunning(t *testing.T) {
 		t.Fatal("missing proxy pidfile reported as running")
 	}
 
-	sock := filepath.Join(dir, vncSockName)
-	proxy := exec.Command(os.Args[0], "-test.run=TestVNCProxyHelperProcess", "--", vncProxyOp, sock)
-	proxy.Env = append(os.Environ(), "COCOON_MACOS_VNC_PROXY_HELPER=1")
-	if err := proxy.Start(); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = proxy.Process.Kill()
-		_ = proxy.Wait()
-	})
-	if err := utils.WritePIDFile(filepath.Join(dir, vncProxyPID), proxy.Process.Pid); err != nil {
-		t.Fatal(err)
-	}
+	spawnTestProxy(t, dir)
 
 	if err := utils.WaitFor(t.Context(), 2*time.Second, 10*time.Millisecond, func() (bool, error) {
 		return vncProxyRunning(dir), nil
@@ -93,4 +81,21 @@ func TestVNCProxyHelperProcess(t *testing.T) {
 	}
 	time.Sleep(time.Minute)
 	os.Exit(0)
+}
+
+func spawnTestProxy(t *testing.T, dir string) {
+	t.Helper()
+	sock := filepath.Join(dir, vncSockName)
+	proxy := exec.Command(os.Args[0], "-test.run=TestVNCProxyHelperProcess", "--", vncProxyOp, sock)
+	proxy.Env = append(os.Environ(), "COCOON_MACOS_VNC_PROXY_HELPER=1")
+	if err := proxy.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = proxy.Process.Kill()
+		_ = proxy.Wait()
+	})
+	if err := utils.WritePIDFile(filepath.Join(dir, vncProxyPID), proxy.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Summary

- stop the detached VNC proxy immediately after a forced restore terminates QEMU
- preserve the VNC display and in-memory password for the subsequent relaunch

## Why

A running CNI VM restored with `--force --vnc-password` could return on a record-save, snapshot-validation, or snapshot-apply failure before `launch` reaped the old proxy. The host listener then remained alive even though QEMU was stopped.

The cleanup now happens at the QEMU termination boundary. A successful relaunch keeps the same behavior, and its existing cleanup remains an idempotent no-op.

## Validation

- full static review of the restore and VNC proxy call paths
- `git diff --check`
- lint, unit tests, and builds not run per the requested source-only boundary; repository CI remains authoritative