### PR TITLE
fix: treat any HMP reply to set_password as a rejection

### DIFF
--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -24,7 +24,10 @@ import (
 	"github.com/cocoonstack/cocoon/utils"
 )
 
-const vmCleanupTimeout = 30 * time.Second
+const (
+	vmCleanupTimeout = 30 * time.Second
+	hmpPrompt        = "(qemu) "
+)
 
 func loadRec(dir string) (*record, error) {
 	var r record
@@ -342,7 +345,7 @@ func setVNCPassword(ctx context.Context, monSock, pw string) error {
 	defer func() { _ = conn.Close() }()
 	// the monitor discards input until its first prompt, so an early set_password is silently lost
 	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
-	if _, ok := readUntil(conn, "(qemu)"); !ok {
+	if _, ok := readUntil(conn, hmpPrompt); !ok {
 		return errors.New("monitor prompt not seen")
 	}
 	if _, err := fmt.Fprintf(conn, "set_password vnc %s\n", pw); err != nil {
@@ -350,7 +353,10 @@ func setVNCPassword(ctx context.Context, monSock, pw string) error {
 	}
 	// wait for the next prompt so QEMU has executed the line before we close (HMP echoes char-by-char)
 	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	out, _ := readUntil(conn, "(qemu)")
+	out, ok := readUntil(conn, hmpPrompt)
+	if !ok {
+		return errors.New("monitor closed before answering set_password")
+	}
 	if hmpReplied(out) {
 		// HMP reports failure only by printing; out echoes the typed password, so never surface it
 		return errors.New("qemu rejected set_password (vnc display not active?)")
@@ -361,7 +367,7 @@ func setVNCPassword(ctx context.Context, monSock, pw string) error {
 func hmpReplied(out string) bool {
 	for line := range strings.SplitSeq(out, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "(qemu)") || strings.Contains(line, "set_password") {
+		if line == "" || strings.HasPrefix(line, strings.TrimSpace(hmpPrompt)) || strings.Contains(line, "set_password") {
 			continue
 		}
 		return true

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -351,11 +351,22 @@ func setVNCPassword(ctx context.Context, monSock, pw string) error {
 	// wait for the next prompt so QEMU has executed the line before we close (HMP echoes char-by-char)
 	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 	out, _ := readUntil(conn, "(qemu)")
-	if strings.Contains(out, "Could not") {
-		// out echoes the typed "set_password vnc <pw>" line — never surface it
+	if hmpReplied(out) {
+		// HMP reports failure only by printing; out echoes the typed password, so never surface it
 		return errors.New("qemu rejected set_password (vnc display not active?)")
 	}
 	return nil
+}
+
+func hmpReplied(out string) bool {
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "(qemu)") || strings.Contains(line, "set_password") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func readUntil(conn net.Conn, marker string) (string, bool) {

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,6 +149,29 @@ func TestVMDirPrefixSeparatesSiblingNames(t *testing.T) {
 	}
 	if strings.Contains("qemu\x00-drive\x00file=/state/vms/foo-clone/disk.qcow2", needle) {
 		t.Fatal("sibling foo-clone matched")
+	}
+}
+
+func TestReadUntilWaitsForTheFullPrompt(t *testing.T) {
+	client, monitor := net.Pipe()
+	go func() {
+		for _, chunk := range []string{" set_pass", "word vnc (qemu)\r\n", "Error: No VNC display is present\r\n", "(qemu) "} {
+			_, _ = monitor.Write([]byte(chunk))
+		}
+		_ = monitor.Close()
+	}()
+	out, ok := readUntil(client, hmpPrompt)
+	if !ok || !hmpReplied(out) {
+		t.Fatalf("readUntil = (%q, %v), want the rejection after the echoed prompt-shaped password", out, ok)
+	}
+
+	client, monitor = net.Pipe()
+	go func() {
+		_, _ = monitor.Write([]byte(" set_password vnc abcd\r\n"))
+		_ = monitor.Close()
+	}()
+	if out, ok := readUntil(client, hmpPrompt); ok {
+		t.Errorf("readUntil = (%q, true), want false when the monitor closes before the prompt", out)
 	}
 }
 

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -150,3 +150,19 @@ func TestVMDirPrefixSeparatesSiblingNames(t *testing.T) {
 		t.Fatal("sibling foo-clone matched")
 	}
 }
+
+func TestHMPRepliedFlagsAnyMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"echo and prompt only", " set_password vnc abcd\r\n(qemu) ", false},
+		{"invalid parameter", " set_password vnc ab cd\r\nError: invalid parameter value: cd\r\n(qemu) ", true},
+		{"display inactive", " set_password vnc abcd\r\nCould not set password\r\n(qemu) ", true},
+	} {
+		if got := hmpReplied(tc.out); got != tc.want {
+			t.Errorf("%s: hmpReplied = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -153,24 +153,11 @@ func TestVMDirPrefixSeparatesSiblingNames(t *testing.T) {
 }
 
 func TestReadUntilWaitsForTheFullPrompt(t *testing.T) {
-	client, monitor := net.Pipe()
-	go func() {
-		for _, chunk := range []string{" set_pass", "word vnc (qemu)\r\n", "Error: No VNC display is present\r\n", "(qemu) "} {
-			_, _ = monitor.Write([]byte(chunk))
-		}
-		_ = monitor.Close()
-	}()
-	out, ok := readUntil(client, hmpPrompt)
+	out, ok := hmpTranscript(" set_pass", "word vnc (qemu)\r\n", "Error: No VNC display is present\r\n", "(qemu) ")
 	if !ok || !hmpReplied(out) {
 		t.Fatalf("readUntil = (%q, %v), want the rejection after the echoed prompt-shaped password", out, ok)
 	}
-
-	client, monitor = net.Pipe()
-	go func() {
-		_, _ = monitor.Write([]byte(" set_password vnc abcd\r\n"))
-		_ = monitor.Close()
-	}()
-	if out, ok := readUntil(client, hmpPrompt); ok {
+	if out, ok := hmpTranscript(" set_password vnc abcd\r\n"); ok {
 		t.Errorf("readUntil = (%q, true), want false when the monitor closes before the prompt", out)
 	}
 }
@@ -189,4 +176,15 @@ func TestHMPRepliedFlagsAnyMessage(t *testing.T) {
 			t.Errorf("%s: hmpReplied = %v, want %v", tc.name, got, tc.want)
 		}
 	}
+}
+
+func hmpTranscript(chunks ...string) (string, bool) {
+	client, monitor := net.Pipe()
+	go func() {
+		for _, chunk := range chunks {
+			_, _ = monitor.Write([]byte(chunk))
+		}
+		_ = monitor.Close()
+	}()
+	return readUntil(client, hmpPrompt)
 }


### PR DESCRIPTION
Seen on hardware while verifying #39: with the whitespace rule absent, `set_password vnc ab cd` made QEMU print `Error: invalid parameter value: cd`, `setVNCPassword` only matched `Could not`, and the VM booted with `password=on`, no password set, and `vnc_password_set: true` in its record. #39's validation closes that input; this closes the check itself, so any HMP error wording is a rejection. The error message stays fixed because the monitor echoes the password. Unit test covers the echo-only reply, the invalid-parameter reply, and the display-inactive reply.

Gates: `make lint` (darwin, linux) 0 issues, `make fmt-check`, `asl` both GOOS, `go test ./cmd/vm/`.