### PR TITLE
fix: HMP echo detection and CNI dirs in the VM record

### DIFF
--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -138,6 +139,8 @@ func (h *Handler) clone(cmd *cobra.Command, srcRec *record, name string) (retErr
 	}
 	tapFlag, _ := cmd.Flags().GetString("tap")
 	r.Tap = tapFlag
+	r.CNIConfDir = cmp.Or(flagOr(cmd, "cni-conf-dir", ""), srcRec.CNIConfDir)
+	r.CNIBinDir = cmp.Or(flagOr(cmd, "cni-bin-dir", ""), srcRec.CNIBinDir)
 	if err = applyNet(cmd, r); err != nil {
 		return err
 	}

--- a/cmd/vm/clone.go
+++ b/cmd/vm/clone.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -139,8 +138,8 @@ func (h *Handler) clone(cmd *cobra.Command, srcRec *record, name string) (retErr
 	}
 	tapFlag, _ := cmd.Flags().GetString("tap")
 	r.Tap = tapFlag
-	r.CNIConfDir = cmp.Or(flagOr(cmd, "cni-conf-dir", ""), srcRec.CNIConfDir)
-	r.CNIBinDir = cmp.Or(flagOr(cmd, "cni-bin-dir", ""), srcRec.CNIBinDir)
+	r.CNIConfDir = flagOr(cmd, "cni-conf-dir", srcRec.CNIConfDir)
+	r.CNIBinDir = flagOr(cmd, "cni-bin-dir", srcRec.CNIBinDir)
 	if err = applyNet(cmd, r); err != nil {
 		return err
 	}

--- a/cmd/vm/commands.go
+++ b/cmd/vm/commands.go
@@ -72,6 +72,8 @@ func Command(h *Handler) *cobra.Command {
 		RunE:  h.RM,
 	}
 	rmCmd.Flags().Bool("force", false, "force kill (immediate SIGKILL, skip the ACPI grace window)")
+	rmCmd.Flags().String("cni-conf-dir", "", "CNI config dir for a VM created before the record remembered it")
+	rmCmd.Flags().String("cni-bin-dir", "", "CNI plugin dir for a VM created before the record remembered it")
 
 	snapshotCmd := &cobra.Command{
 		Use:   "snapshot VM",

--- a/cmd/vm/handler.go
+++ b/cmd/vm/handler.go
@@ -53,6 +53,8 @@ type record struct {
 	TapOwned     bool         `json:"tap_owned,omitempty"`  // cocoon auto-created the TAP (tear down on rm); false for user --tap
 	BridgeDev    string       `json:"bridge_dev,omitempty"` // bridge to enslave the TAP to; persisted so rm can tear down without --bridge
 	Netns        string       `json:"netns,omitempty"`      // netns path the qemu process runs in (CNI); "" otherwise
+	CNIConfDir   string       `json:"cni_conf_dir,omitempty"`
+	CNIBinDir    string       `json:"cni_bin_dir,omitempty"`
 
 	PID int `json:"pid"`
 

--- a/cmd/vm/lifecycle.go
+++ b/cmd/vm/lifecycle.go
@@ -207,11 +207,13 @@ func (h *Handler) create(cmd *cobra.Command, image, name string) (r *record, ret
 	tap, _ := cmd.Flags().GetString("tap")
 	huge, _ := cmd.Flags().GetBool("hugepages")
 	exitOnReboot, _ := cmd.Flags().GetBool("exit-on-reboot")
+	cniConfDir, _ := cmd.Flags().GetString("cni-conf-dir")
+	cniBinDir, _ := cmd.Flags().GetString("cni-bin-dir")
 	r = &record{
 		Name: name, Image: image, ImageDigest: digest, Disk: overlay, OVMFCode: code, OVMFVars: ovmfVars,
 		CPUs: cpus, Memory: mem, Storage: storage, VNCDisp: vnc, SSHPort: ssh, VNCPass: vncPass, NetMode: netMode, Tap: tap, Hugepages: huge,
-		ExitOnReboot: exitOnReboot,
-		VMID:         utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
+		ExitOnReboot: exitOnReboot, CNIConfDir: cniConfDir, CNIBinDir: cniBinDir,
+		VMID: utils.GenerateID(), Created: time.Now().Format(time.RFC3339),
 	}
 	if r.DataDisks, err = createDataDisks(ctx, dir, diskSpecs); err != nil {
 		return nil, err

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -27,7 +27,7 @@ import (
 // netScope keys cocoon-macos's host TAP/netns families apart from a co-hosted cocoon's, so neither GC reclaims the other's live guests.
 const netScope = "cm"
 
-// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family; the CNI dirs resolve flag, then record, then default.
+// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family.
 func netConf(cmd *cobra.Command, r *record) *config.Config {
 	return &config.Config{
 		RootDir:    home.Dir(cmd),

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -27,13 +27,13 @@ import (
 // netScope keys cocoon-macos's host TAP/netns families apart from a co-hosted cocoon's, so neither GC reclaims the other's live guests.
 const netScope = "cm"
 
-// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family; the CNI dirs come from the record so rm needs no flags.
+// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family; the CNI dirs resolve flag, then record, then default.
 func netConf(cmd *cobra.Command, r *record) *config.Config {
 	return &config.Config{
 		RootDir:    home.Dir(cmd),
 		DNS:        "8.8.8.8,1.1.1.1",
-		CNIConfDir: cmp.Or(r.CNIConfDir, "/etc/cni/net.d"),
-		CNIBinDir:  cmp.Or(r.CNIBinDir, "/opt/cni/bin"),
+		CNIConfDir: cmp.Or(flagOr(cmd, "cni-conf-dir", ""), r.CNIConfDir, "/etc/cni/net.d"),
+		CNIBinDir:  cmp.Or(flagOr(cmd, "cni-bin-dir", ""), r.CNIBinDir, "/opt/cni/bin"),
 		NetScope:   netScope,
 	}
 }

--- a/cmd/vm/net_linux.go
+++ b/cmd/vm/net_linux.go
@@ -27,20 +27,20 @@ import (
 // netScope keys cocoon-macos's host TAP/netns families apart from a co-hosted cocoon's, so neither GC reclaims the other's live guests.
 const netScope = "cm"
 
-// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family.
-func netConf(cmd *cobra.Command) *config.Config {
+// netConf is the cocoon network config: bridge/CNI provisioning shares cocoon's forwarding plane, keyed under our own device family; the CNI dirs come from the record so rm needs no flags.
+func netConf(cmd *cobra.Command, r *record) *config.Config {
 	return &config.Config{
 		RootDir:    home.Dir(cmd),
 		DNS:        "8.8.8.8,1.1.1.1",
-		CNIConfDir: flagOr(cmd, "cni-conf-dir", "/etc/cni/net.d"),
-		CNIBinDir:  flagOr(cmd, "cni-bin-dir", "/opt/cni/bin"),
+		CNIConfDir: cmp.Or(r.CNIConfDir, "/etc/cni/net.d"),
+		CNIBinDir:  cmp.Or(r.CNIBinDir, "/opt/cni/bin"),
 		NetScope:   netScope,
 	}
 }
 
 // newProvider builds the cocoon network provider: tap/bridge both use the bridge backend (QEMU opens the TAP in the host netns, so it must be a host-side bridge port); cni's TAP lives in a netns.
 func newProvider(cmd *cobra.Command, r *record) (network.Network, error) {
-	conf := netConf(cmd)
+	conf := netConf(cmd, r)
 	switch r.NetMode {
 	case netCNI:
 		store, err := metajson.Open(cni.NewConfig(conf).JSONNamespace())
@@ -100,7 +100,7 @@ func teardownNet(ctx context.Context, cmd *cobra.Command, r *record) error {
 	}
 	bridgeMode := r.NetMode == netTAP || r.NetMode == netBridge
 	if bridgeMode {
-		defer bridge.CleanupTAPs(netConf(cmd).BridgeTAPPrefix(), []string{r.VMID})
+		defer bridge.CleanupTAPs(netConf(cmd, r).BridgeTAPPrefix(), []string{r.VMID})
 	}
 	logger := log.WithFunc("cmd.vm.teardownNet")
 	provider, err := newProvider(cmd, r)

--- a/cmd/vm/net_linux_test.go
+++ b/cmd/vm/net_linux_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/cocoonstack/cocoon-macos/home"
 )
 
+func TestNetConfResolvesFlagThenRecordThenDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("cni-conf-dir", "", "")
+	cmd.Flags().String("cni-bin-dir", "", "")
+	if got := netConf(cmd, &record{}).CNIConfDir; got != "/etc/cni/net.d" {
+		t.Errorf("default CNIConfDir = %q", got)
+	}
+	if got := netConf(cmd, &record{CNIConfDir: "/rec/net.d", CNIBinDir: "/rec/bin"}).CNIBinDir; got != "/rec/bin" {
+		t.Errorf("record CNIBinDir = %q", got)
+	}
+	if err := cmd.Flags().Set("cni-conf-dir", "/flag/net.d"); err != nil {
+		t.Fatal(err)
+	}
+	if got := netConf(cmd, &record{CNIConfDir: "/rec/net.d"}).CNIConfDir; got != "/flag/net.d" {
+		t.Errorf("flag CNIConfDir = %q, want the flag over the record", got)
+	}
+}
+
 func TestNetConfScope(t *testing.T) {
 	conf := netConf(&cobra.Command{}, &record{})
 	if got, want := conf.NetScope, "cm"; got != want {

--- a/cmd/vm/net_linux_test.go
+++ b/cmd/vm/net_linux_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNetConfScope(t *testing.T) {
-	conf := netConf(&cobra.Command{})
+	conf := netConf(&cobra.Command{}, &record{})
 	if got, want := conf.NetScope, "cm"; got != want {
 		t.Errorf("NetScope = %q, want %q", got, want)
 	}

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -365,9 +365,14 @@ func setVNCPassword(ctx context.Context, monSock, pw string) error {
 }
 
 func hmpReplied(out string) bool {
+	echoed := false
 	for line := range strings.SplitSeq(out, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, strings.TrimSpace(hmpPrompt)) || strings.Contains(line, "set_password") {
+		if line == "" || strings.HasPrefix(line, strings.TrimSpace(hmpPrompt)) {
+			continue
+		}
+		if !echoed && strings.HasPrefix(line, "set_password ") {
+			echoed = true
 			continue
 		}
 		return true

--- a/cmd/vm/utils.go
+++ b/cmd/vm/utils.go
@@ -371,7 +371,7 @@ func hmpReplied(out string) bool {
 		if line == "" || strings.HasPrefix(line, strings.TrimSpace(hmpPrompt)) {
 			continue
 		}
-		if !echoed && strings.HasPrefix(line, "set_password ") {
+		if !echoed && strings.Contains(line, "set_password ") {
 			echoed = true
 			continue
 		}

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -168,6 +168,7 @@ func TestHMPRepliedFlagsAnyMessage(t *testing.T) {
 		{"echo and prompt only", " set_password vnc abcd\r\n(qemu) ", false},
 		{"invalid parameter", " set_password vnc ab cd\r\nError: invalid parameter value: cd\r\n(qemu) ", true},
 		{"display inactive", " set_password vnc abcd\r\nCould not set password\r\n(qemu) ", true},
+		{"unterminated quote", " set_password vnc \"abc\r\nset_password: string expected\r\nTry \"help set_password\" for more information\r\n(qemu) ", true},
 	} {
 		if got := hmpReplied(tc.out); got != tc.want {
 			t.Errorf("%s: hmpReplied = %v, want %v", tc.name, got, tc.want)

--- a/cmd/vm/utils_test.go
+++ b/cmd/vm/utils_test.go
@@ -169,6 +169,8 @@ func TestHMPRepliedFlagsAnyMessage(t *testing.T) {
 		{"invalid parameter", " set_password vnc ab cd\r\nError: invalid parameter value: cd\r\n(qemu) ", true},
 		{"display inactive", " set_password vnc abcd\r\nCould not set password\r\n(qemu) ", true},
 		{"unterminated quote", " set_password vnc \"abc\r\nset_password: string expected\r\nTry \"help set_password\" for more information\r\n(qemu) ", true},
+		{"readline redraw echo", "s\x1b[K\x1b[Dse\x1b[K\x1b[D\x1b[Dset_password vnc abcd\r\n(qemu) ", false},
+		{"readline redraw then rejection", "s\x1b[K\x1b[Dset_password vnc \"abc\r\nset_password: string expected\r\n(qemu) ", true},
 	} {
 		if got := hmpReplied(tc.out); got != tc.want {
 			t.Errorf("%s: hmpReplied = %v, want %v", tc.name, got, tc.want)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -32,7 +32,9 @@ goes straight to that IP (no port-forward).
 `--cni-conf-dir` (default `/etc/cni/net.d`) and `--cni-bin-dir` (default
 `/opt/cni/bin`) point at a non-standard CNI installation; both are ignored by
 the other net modes and are remembered in the VM record, so `rm` tears the
-NIC down without repeating them.
+NIC down without repeating them; a clone inherits them from its source. A VM
+created before the record carried them takes `rm --cni-conf-dir` and
+`rm --cni-bin-dir` once.
 
 ## Clones
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -31,7 +31,8 @@ goes straight to that IP (no port-forward).
 
 `--cni-conf-dir` (default `/etc/cni/net.d`) and `--cni-bin-dir` (default
 `/opt/cni/bin`) point at a non-standard CNI installation; both are ignored by
-the other net modes.
+the other net modes and are remembered in the VM record, so `rm` tears the
+NIC down without repeating them.
 
 ## Clones
 


### PR DESCRIPTION
Two findings from the 2026-09-03 final verification lane on the testbed.

- `hmpReplied` skipped every line containing `set_password`, so a password beginning with a double quote (QEMU answers `set_password: string expected` and `Try "help set_password" ...`) was reported as set while the guest had none. Only the echoed command line is skipped now; regression case added to the HMP transcript table.
- `vm rm` had no `--cni-conf-dir`/`--cni-bin-dir`, so a CNI VM created against a non-default CNI installation could never release its NIC. `run` and `clone` persist both dirs in the record and every provisioning verb reads them from there; older records keep the defaults. Documented in `docs/networking.md`.

Gates: `make lint` 0 issues on GOOS=linux and darwin, `make fmt-check`, `asl ./...` on both GOOS, `GOOS=linux go vet ./...`, `go test -race -count=1 ./...`.